### PR TITLE
⚡ Optimize Plymouth theme password bullet scaling

### DIFF
--- a/packages/plymouth-marchyo-theme/marchyo.script
+++ b/packages/plymouth-marchyo-theme/marchyo.script
@@ -117,7 +117,8 @@ fun stop_fake_progress()
 lock.image = Image("lock.png");
 entry.image = Image("entry.png");
 bullet.image = Image("bullet.png");
-bullet.scaled_image = bullet.image.Scale(7, 7);
+global.bullet_size = 7;
+bullet.scaled_image = bullet.image.Scale(global.bullet_size, global.bullet_size);
 
 entry.sprite = Sprite(entry.image);
 entry.x = Window.GetWidth()/2 - entry.image.GetWidth() / 2;
@@ -184,8 +185,8 @@ fun display_password_callback (prompt, bullets)
           {
             # Scale bullet image to 7x7 pixels
             bullet.sprites[index] = Sprite(bullet.scaled_image);
-            bullet.x = entry.x + 20 + index * (7 + 5);
-            bullet.y = entry.y + entry.image.GetHeight() / 2 - 3.5;
+            bullet.x = entry.x + 20 + index * (global.bullet_size + 5);
+            bullet.y = entry.y + entry.image.GetHeight() / 2 - global.bullet_size / 2;
             bullet.sprites[index].SetPosition(bullet.x, bullet.y, 10002);
           }
         bullet.sprites[index].SetOpacity(1);

--- a/packages/plymouth-marchyo-theme/marchyo.script
+++ b/packages/plymouth-marchyo-theme/marchyo.script
@@ -117,6 +117,7 @@ fun stop_fake_progress()
 lock.image = Image("lock.png");
 entry.image = Image("entry.png");
 bullet.image = Image("bullet.png");
+bullet.scaled_image = bullet.image.Scale(7, 7);
 
 entry.sprite = Sprite(entry.image);
 entry.x = Window.GetWidth()/2 - entry.image.GetWidth() / 2;
@@ -182,8 +183,7 @@ fun display_password_callback (prompt, bullets)
         if (!bullet.sprites[index])
           {
             # Scale bullet image to 7x7 pixels
-            scaled_bullet = bullet.image.Scale(7, 7);
-            bullet.sprites[index] = Sprite(scaled_bullet);
+            bullet.sprites[index] = Sprite(bullet.scaled_image);
             bullet.x = entry.x + 20 + index * (7 + 5);
             bullet.y = entry.y + entry.image.GetHeight() / 2 - 3.5;
             bullet.sprites[index].SetPosition(bullet.x, bullet.y, 10002);


### PR DESCRIPTION
💡 **What:**
- Defined `bullet.scaled_image` globally in `packages/plymouth-marchyo-theme/marchyo.script` by scaling `bullet.image` once.
- Updated the loop in `display_password_callback` to use the pre-scaled `bullet.scaled_image` instead of calling `Scale(7, 7)` repeatedly.

🎯 **Why:**
- The previous implementation scaled the bullet image every time a new bullet sprite was needed (i.e., for every character typed in the password field).
- Image scaling is a relatively expensive operation. Doing it inside a loop that runs on user input adds unnecessary CPU overhead.
- Pre-scaling ensures the operation happens only once during initialization.

📊 **Measured Improvement:**
- While direct benchmarking of the boot splash screen is impractical in this environment, the optimization removes an O(N) image processing operation (where N is password length) from the input handling path, making it O(1) in terms of image processing. This is a theoretically sound and clear performance win.

---
*PR created automatically by Jules for task [15270955543023460565](https://jules.google.com/task/15270955543023460565) started by @Jylhis*