### PR TITLE
Fix Mako configuration syntax for urgency criteria

### DIFF
--- a/modules/home/mako.nix
+++ b/modules/home/mako.nix
@@ -42,15 +42,15 @@ in
           border-color = "#${colors.base0D}";
           progress-color = "over #${colors.base02}";
 
-          urgency-low = {
+          "urgency=low" = {
             border-color = "#${colors.base03}";
           };
 
-          urgency-normal = {
+          "urgency=normal" = {
             border-color = "#${colors.base0D}";
           };
 
-          urgency-critical = {
+          "urgency=critical" = {
             border-color = "#${colors.base08}";
             text-color = "#${colors.base08}";
           };


### PR DESCRIPTION
The `mako` notification daemon failed to start due to invalid configuration syntax in the generated config file. The error message `Invalid boolean criteria field 'urgency-critical'` indicated that the urgency sections were being generated as `[urgency-critical]` instead of `[urgency=critical]`.

This change updates `modules/home/mako.nix` to use quoted keys for the urgency settings, ensuring that Home Manager generates the correct INI section headers.

Verified by running `nix build .#checks.x86_64-linux.eval-themes`, which includes the mako configuration.

---
*PR created automatically by Jules for task [3391341783167243891](https://jules.google.com/task/3391341783167243891) started by @Jylhis*