### PR TITLE
⚡ Optimize Plymouth progress bar scaling

### DIFF
--- a/packages/plymouth-marchyo-theme/marchyo.script
+++ b/packages/plymouth-marchyo-theme/marchyo.script
@@ -21,6 +21,7 @@ global.animation_frame = 0;
 global.fake_progress_start_time = 0;  # Track when fake progress started
 global.password_shown = 0;  # Track if password dialog has been shown
 global.max_progress = 0.0;  # Track the maximum progress reached to prevent backwards movement
+global.last_width = 0;      # Track the last width to avoid unnecessary scaling
 
 fun refresh_callback ()
   {
@@ -63,8 +64,13 @@ fun update_progress_bar(progress)
         width = Math.Int(progress_bar.original_image.GetWidth() * progress);
         if (width < 1) width = 1;  # Ensure minimum width of 1 pixel
         
-        progress_bar.image = progress_bar.original_image.Scale(width, progress_bar.original_image.GetHeight());
-        progress_bar.sprite.SetImage(progress_bar.image);
+        # Optimization: Only scale if width changed
+        if (width != global.last_width)
+          {
+            global.last_width = width;
+            progress_bar.image = progress_bar.original_image.Scale(width, progress_bar.original_image.GetHeight());
+            progress_bar.sprite.SetImage(progress_bar.image);
+          }
       }
   }
 

--- a/packages/plymouth-marchyo-theme/marchyo.script
+++ b/packages/plymouth-marchyo-theme/marchyo.script
@@ -21,7 +21,7 @@ global.animation_frame = 0;
 global.fake_progress_start_time = 0;  # Track when fake progress started
 global.password_shown = 0;  # Track if password dialog has been shown
 global.max_progress = 0.0;  # Track the maximum progress reached to prevent backwards movement
-global.last_width = 0;      # Track the last width to avoid unnecessary scaling
+global.last_width = 1;      # Track the last width to avoid unnecessary scaling
 
 fun refresh_callback ()
   {


### PR DESCRIPTION
💡 **What:**
Optimized `update_progress_bar` in `packages/plymouth-marchyo-theme/marchyo.script` to cache the previous progress bar width (`global.last_width`) and only re-scale the image when the calculated integer width actually changes.

🎯 **Why:**
The original code performed an `Image.Scale()` operation on every progress update (which happens frequently during boot) even if the resulting pixel width remained the same due to integer truncation. This redundant scaling wasted CPU cycles.

📊 **Measured Improvement:**
While it is not practical to benchmark Plymouth boot splash performance in this environment, avoiding `Image.Scale()` (a pixel resampling operation) for redundant updates is a clear performance win. If the progress bar is 500px wide, `Scale` would be called ~100 times per 1% of visual change in the worst case (assuming high frequency updates). Debouncing this to only when pixels change reduces `Scale` calls to exactly the number of horizontal pixels (e.g. 500 calls max), significantly reducing CPU load during boot.

---
*PR created automatically by Jules for task [16673296682432816095](https://jules.google.com/task/16673296682432816095) started by @Jylhis*