### PR TITLE
Configure Noctalia shell with systemd and calendar support

### DIFF
--- a/modules/home/noctalia.nix
+++ b/modules/home/noctalia.nix
@@ -9,7 +9,7 @@
     programs.noctalia-shell = {
       enable = lib.mkDefault true;
       systemd.enable = true;
-      package = noctalia.packages.${pkgs.stdenv.hostPlatform.system}.default.override {
+      package = noctalia.packages.${pkgs.system}.default.override {
         calendarSupport = true;
       };
     };

--- a/modules/home/noctalia.nix
+++ b/modules/home/noctalia.nix
@@ -1,4 +1,9 @@
-{ lib, pkgs, noctalia, ... }:
+{
+  lib,
+  pkgs,
+  noctalia,
+  ...
+}:
 {
   config = {
     programs.noctalia-shell = {

--- a/modules/home/noctalia.nix
+++ b/modules/home/noctalia.nix
@@ -1,6 +1,12 @@
-{ lib, ... }:
+{ lib, pkgs, noctalia, ... }:
 {
   config = {
-    programs.noctalia-shell.enable = lib.mkDefault true;
+    programs.noctalia-shell = {
+      enable = lib.mkDefault true;
+      systemd.enable = true;
+      package = noctalia.packages.${pkgs.stdenv.hostPlatform.system}.default.override {
+        calendarSupport = true;
+      };
+    };
   };
 }

--- a/modules/nixos/desktop-config.nix
+++ b/modules/nixos/desktop-config.nix
@@ -27,6 +27,7 @@ in
         interval = "daily";
       };
       gnome.gnome-keyring.enable = lib.mkDefault true;
+      gnome.evolution-data-server.enable = lib.mkDefault true;
       gvfs.enable = lib.mkDefault true;
     };
 


### PR DESCRIPTION
Configures Noctalia shell by enabling the evolution-data-server for calendar support and setting up the systemd service via Home Manager with the necessary package override.

---
*PR created automatically by Jules for task [13460955874838960822](https://jules.google.com/task/13460955874838960822) started by @Jylhis*