### PR TITLE
❄️ Nixie: Update flake inputs & fix checks

### DIFF
--- a/.Jules/nixie.md
+++ b/.Jules/nixie.md
@@ -1,0 +1,6 @@
+# Nixie's Journal
+
+This journal documents critical learnings from maintaining the Nix Flake configuration.
+
+## Format
+## YYYY-MM-DD - [Title] **Learning:** [Technical insight] **Action:** [Constraint to apply next time]

--- a/flake.lock
+++ b/flake.lock
@@ -197,12 +197,12 @@
         ]
       },
       "locked": {
-        "lastModified": 1769952507,
-        "narHash": "sha256-eNTfxT3v8b7s1dqswgposi5Y1CUMoOUhQKiy29QY25U=",
-        "rev": "b59376563943ce163b2553aeb63d0c170967d74e",
-        "revCount": 6182,
+        "lastModified": 1770491427,
+        "narHash": "sha256-8b+0vixdqGnIIcgsPhjdX7EGPdzcVQqYxF+ujjex654=",
+        "rev": "cbd8a72e5fe6af19d40e2741dc440d9227836860",
+        "revCount": 6203,
         "type": "tarball",
-        "url": "https://api.flakehub.com/f/pinned/nix-community/home-manager/0.1.6182%2Brev-b59376563943ce163b2553aeb63d0c170967d74e/019c1964-e0da-7083-bff5-9336b536bc5c/source.tar.gz"
+        "url": "https://api.flakehub.com/f/pinned/nix-community/home-manager/0.1.6203%2Brev-cbd8a72e5fe6af19d40e2741dc440d9227836860/019c3984-3464-7a71-83aa-f878a6fb8d6f/source.tar.gz"
       },
       "original": {
         "type": "tarball",
@@ -343,12 +343,12 @@
     },
     "nixpkgs_4": {
       "locked": {
-        "lastModified": 1769789167,
-        "narHash": "sha256-kKB3bqYJU5nzYeIROI82Ef9VtTbu4uA3YydSk/Bioa8=",
-        "rev": "62c8382960464ceb98ea593cb8321a2cf8f9e3e5",
-        "revCount": 937308,
+        "lastModified": 1770197578,
+        "narHash": "sha256-AYqlWrX09+HvGs8zM6ebZ1pwUqjkfpnv8mewYwAo+iM=",
+        "rev": "00c21e4c93d963c50d4c0c89bfa84ed6e0694df2",
+        "revCount": 940249,
         "type": "tarball",
-        "url": "https://api.flakehub.com/f/pinned/NixOS/nixpkgs/0.1.937308%2Brev-62c8382960464ceb98ea593cb8321a2cf8f9e3e5/019c1900-34aa-72c1-8ea0-ab231e456895/source.tar.gz"
+        "url": "https://api.flakehub.com/f/pinned/NixOS/nixpkgs/0.1.940249%2Brev-00c21e4c93d963c50d4c0c89bfa84ed6e0694df2/019c2c37-21f9-727c-86c5-0523e601d163/source.tar.gz"
       },
       "original": {
         "type": "tarball",
@@ -362,11 +362,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1769941423,
-        "narHash": "sha256-0XUE2RBowHku+bsthHkE+GUZRcCqHGMYOnBCMa+AdPo=",
+        "lastModified": 1770571663,
+        "narHash": "sha256-Vqd5senFyozLb7EM7JvScUqC56eQFfSo+xvGFuEVn+8=",
         "owner": "noctalia-dev",
         "repo": "noctalia-shell",
-        "rev": "7fef62741591053818ee0b94cf45f64967ce5bbe",
+        "rev": "f9f668dbe64396100d6a8d89618737d3503d013a",
         "type": "github"
       },
       "original": {
@@ -427,12 +427,12 @@
         ]
       },
       "locked": {
-        "lastModified": 1769691507,
-        "narHash": "sha256-8aAYwyVzSSwIhP2glDhw/G0i5+wOrren3v6WmxkVonM=",
-        "rev": "28b19c5844cc6e2257801d43f2772a4b4c050a1b",
-        "revCount": 536,
+        "lastModified": 1770228511,
+        "narHash": "sha256-wQ6NJSuFqAEmIg2VMnLdCnUc0b7vslUohqqGGD+Fyxk=",
+        "rev": "337a4fe074be1042a35086f15481d763b8ddc0e7",
+        "revCount": 541,
         "type": "tarball",
-        "url": "https://api.flakehub.com/f/pinned/numtide/treefmt-nix/0.1.536%2Brev-28b19c5844cc6e2257801d43f2772a4b4c050a1b/019c0ade-c870-74ee-9d5b-2b8095eabce8/source.tar.gz"
+        "url": "https://api.flakehub.com/f/pinned/numtide/treefmt-nix/0.1.541%2Brev-337a4fe074be1042a35086f15481d763b8ddc0e7/019c2c5b-3760-7c08-93c8-51a13f123486/source.tar.gz"
       },
       "original": {
         "type": "tarball",
@@ -447,11 +447,11 @@
         "systems": "systems"
       },
       "locked": {
-        "lastModified": 1769828520,
-        "narHash": "sha256-Ec1qBP3M+aKHhQsvgaEI7gdnTEh4GQCgc19WeOTxuHg=",
+        "lastModified": 1770568129,
+        "narHash": "sha256-ttlXJjnrRVxS18rLNKVWBUlup5F/mK2YILl/NN/wCU8=",
         "owner": "vicinaehq",
         "repo": "vicinae",
-        "rev": "ecfad06ed4b8c7f88f6eaee1c4c9548b0b5fbd55",
+        "rev": "eb1a25363a728ca8ba7864e5556af95f7a90310a",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
❄️ Nixie Report

📦 Updates:
- Updated `home-manager` to `0.1.6203`
- Updated `nixpkgs` to `0.1.940249`
- Updated `noctalia` to `f9f668dbe64396100d6a8d89618737d3503d013a`
- Updated `treefmt-nix` to `0.1.541`
- Updated `vicinae` to `eb1a25363a728ca8ba7864e5556af95f7a90310a`

🛡️ Checks:
- `nix flake check --all-systems` passed successfully.
- `nix fmt` verified.

🔧 Fixes:
- Created `.Jules/nixie.md` to track critical learnings.

---
*PR created automatically by Jules for task [2419233383086857761](https://jules.google.com/task/2419233383086857761) started by @Jylhis*