### PR TITLE
Add VM app for development

### DIFF
--- a/flake.nix
+++ b/flake.nix
@@ -135,7 +135,6 @@
               nixosModules.default
               (
                 {
-                  config,
                   lib,
                   modulesPath,
                   ...
@@ -172,7 +171,10 @@
                   users.users.developer = {
                     isNormalUser = true;
                     password = "password";
-                    extraGroups = [ "wheel" "networkmanager" ];
+                    extraGroups = [
+                      "wheel"
+                      "networkmanager"
+                    ];
                     description = "Marchyo Developer";
                   };
                   services.getty.autologinUser = "developer";

--- a/flake.nix
+++ b/flake.nix
@@ -152,7 +152,7 @@
                   # VM Specs
                   virtualisation = {
                     memorySize = 4096;
-                    cores = 2;
+                    cores = 4;
                     graphics = true;
                   };
 
@@ -165,6 +165,10 @@
                     development.enable = true;
                     media.enable = true;
                     office.enable = true;
+                    users.developer = {
+                      fullname = "Marchyo Developer";
+                      email = "dev@example.org";
+                    };
                   };
 
                   # User config
@@ -175,7 +179,6 @@
                       "wheel"
                       "networkmanager"
                     ];
-                    description = "Marchyo Developer";
                   };
                   services.getty.autologinUser = "developer";
                 }


### PR DESCRIPTION
Added a `vm` app to `flake.nix` which builds and runs a NixOS VM with the default Marchyo configuration (desktop, development, media, office enabled) and uses a wrapper script to run it. Verified that `nix flake check` passes and `nix eval` on the app program returns a valid path.

---
*PR created automatically by Jules for task [18414016644519004203](https://jules.google.com/task/18414016644519004203) started by @Jylhis*