### PR TITLE
Fix hyprpaper DRM/GBM error

### DIFF
--- a/modules/home/hyprland.nix
+++ b/modules/home/hyprland.nix
@@ -488,6 +488,7 @@ in
           "kanshi"
           "vicinae server"
           "fcitx5 -d --replace"
+          "hyprpaper"
 
           # Clipboard
           "wl-paste --type text --watch cliphist store"

--- a/modules/home/hyprpaper.nix
+++ b/modules/home/hyprpaper.nix
@@ -1,4 +1,4 @@
-{ config, ... }:
+{ config, pkgs, ... }:
 let
   selectedWallpaper = "kanagawa-1.png";
   wallpaperDir = "Pictures/Wallpapers";
@@ -12,15 +12,12 @@ in
     };
   };
 
-  services.hyprpaper = {
-    enable = true;
-    settings = {
-      preload = [
-        wallpaper_path
-      ];
-      wallpaper = [
-        ",${wallpaper_path}"
-      ];
-    };
-  };
+  # Manually generate config to avoid systemd service issues with environment variables
+  xdg.configFile."hypr/hyprpaper.conf".text = ''
+    preload = ${wallpaper_path}
+    wallpaper = ,${wallpaper_path}
+  '';
+
+  # Ensure hyprpaper is installed
+  home.packages = [ pkgs.hyprpaper ];
 }


### PR DESCRIPTION
Replaces the systemd service for hyprpaper with manual configuration and execution via Hyprland's `exec-once`. This ensures that hyprpaper inherits the full Wayland/Hyprland environment variables (e.g., GBM_BACKEND, WLR_DRM_DEVICES), resolving the "PRIME export is not supported" and "drmGetDevice failed" errors commonly seen on multi-GPU or VM setups.

---
*PR created automatically by Jules for task [2683406035994152424](https://jules.google.com/task/2683406035994152424) started by @Jylhis*