### PR TITLE
feat: Add keyboard docs and compose key support

### DIFF
--- a/AI_GUIDE.md
+++ b/AI_GUIDE.md
@@ -116,6 +116,7 @@ marchyo.keyboard = {
   options = [ "grp:win_space_toggle" ];    # Super+Space to switch
   autoActivateIME = true;                   # Auto-activate IME on switch
   imeTriggerKey = [ "Super+I" ];           # Manual IME toggle
+  composeKey = "ralt";                     # Compose key (null to disable)
 };
 ```
 

--- a/docs/keyboard.md
+++ b/docs/keyboard.md
@@ -1,0 +1,97 @@
+# Keyboard Configuration
+
+Marchyo provides a unified way to configure keyboard layouts, variants, input methods (IMEs), and XKB options across the system (TTY/console) and the desktop environment (Hyprland + fcitx5).
+
+All keyboard settings are configured under the `marchyo.keyboard.*` namespace.
+
+## Layouts and Input Methods
+
+The `marchyo.keyboard.layouts` option accepts a list of layouts. Each layout can be defined as a simple string or an attribute set for more advanced configuration.
+
+### Simple Layouts
+
+For basic layouts, you can just provide the layout code:
+
+```nix
+marchyo.keyboard.layouts = [
+  "us"
+  "fi"
+  "de"
+];
+```
+
+### Advanced Layouts (Variants and IMEs)
+
+If you need specific layout variants (like US International) or Input Method Engines (IMEs) for languages like Chinese, Japanese, or Korean, use an attribute set:
+
+```nix
+marchyo.keyboard.layouts = [
+  "us"                                   # Simple layout
+  { layout = "us"; variant = "intl"; }   # US international with dead keys
+  { layout = "cn"; ime = "pinyin"; }     # Chinese with Pinyin IME
+  { layout = "jp"; ime = "mozc"; }       # Japanese with Mozc IME
+  { layout = "kr"; ime = "hangul"; }     # Korean with Hangul IME
+];
+```
+
+When an entry includes `ime`, the input method engine will be automatically activated when you switch to that layout.
+
+Available IMEs:
+- `pinyin`: Chinese Pinyin input (requires `fcitx5-chinese-addons`)
+- `mozc`: Japanese input (requires `fcitx5-mozc`)
+- `hangul`: Korean input (requires `fcitx5-hangul`)
+- `unicode`: Unicode character picker
+
+## Keyboard Switching Options
+
+You can customize how you switch between layouts and IMEs.
+
+### XKB Options
+
+Use `marchyo.keyboard.options` to pass standard XKB options. By default, it is set to use Super+Space to toggle layouts:
+
+```nix
+marchyo.keyboard.options = [
+  "grp:win_space_toggle"  # Use Super+Space to switch inputs
+  "ctrl:swapcaps"         # Swap Caps Lock and Left Control
+];
+```
+
+### Compose Key
+
+The compose key allows you to type special characters by pressing the compose key followed by a sequence of characters (e.g., Compose + ' + e = é).
+
+Configure it using `marchyo.keyboard.composeKey`:
+
+```nix
+marchyo.keyboard.composeKey = "ralt";  # Default: Right Alt
+```
+
+Common values:
+- `ralt`: Right Alt key
+- `rwin`: Right Super/Windows key
+- `caps`: Caps Lock key
+- `menu`: Menu key
+- `null`: Disable compose key entirely
+
+### IME Auto-Activation
+
+By default, switching to a layout with an associated IME will automatically activate it. To disable this behavior:
+
+```nix
+marchyo.keyboard.autoActivateIME = false;
+```
+
+### Manual IME Toggle
+
+If you prefer to toggle the IME manually rather than tying it to layout switching, you can specify trigger keys:
+
+```nix
+marchyo.keyboard.imeTriggerKey = [ "Super+I" ];
+```
+
+## How It Works Under the Hood
+
+1. **NixOS (`services.xserver.xkb`)**: The basic layout codes and variants are applied to the console/TTY to provide fallback support outside the graphical environment.
+2. **Hyprland (`home.keyboard`)**: The layout and XKB options are passed to Hyprland's input configuration.
+3. **fcitx5**: Acts as the authoritative input manager in the graphical environment, reading your configured layouts, activating IMEs, and managing layout switching.

--- a/modules/home/keyboard.nix
+++ b/modules/home/keyboard.nix
@@ -42,7 +42,7 @@ in
 
         # Apply XKB options as list (Hyprland will join with commas)
         # Must remain a list - don't convert to string
-        inherit (cfg) options;
+        options = cfg.options ++ lib.optional (cfg.composeKey != null) "compose:${cfg.composeKey}";
       }
       # Only set variant if at least one layout has a variant
       # This avoids issues with empty string lists

--- a/modules/nixos/keyboard.nix
+++ b/modules/nixos/keyboard.nix
@@ -55,7 +55,11 @@ in
       variant = lib.mkDefault (lib.concatStringsSep "," variants);
 
       # Convert list of options to comma-separated string
-      options = lib.mkDefault (lib.concatStringsSep "," cfg.options);
+      options = lib.mkDefault (
+        lib.concatStringsSep "," (
+          cfg.options ++ lib.optional (cfg.composeKey != null) "compose:${cfg.composeKey}"
+        )
+      );
     };
 
     # Enable console keyboard layout switching in TTY

--- a/modules/nixos/options.nix
+++ b/modules/nixos/options.nix
@@ -540,6 +540,23 @@ in
         '';
       };
 
+      composeKey = mkOption {
+        type = types.nullOr types.nonEmptyStr;
+        default = "ralt";
+        example = "rwin";
+        description = ''
+          Sets the XKB Compose key for typing special characters.
+          Common values:
+          - ralt: Right Alt key (default)
+          - rwin: Right Super/Windows key
+          - caps: Caps Lock key
+          - menu: Menu key
+          - null: Disable compose key
+
+          Set to null to disable the compose key entirely.
+        '';
+      };
+
       autoActivateIME = mkOption {
         type = types.bool;
         default = true;

--- a/tests/module-tests.nix
+++ b/tests/module-tests.nix
@@ -114,7 +114,13 @@ in
         "Super+I"
         "Alt+grave"
       ];
+      composeKey = "caps";
     };
+  });
+
+  # Test 6b: Keyboard with compose key disabled
+  eval-keyboard-no-compose = testNixOS "keyboard-no-compose" (withTestUser {
+    marchyo.keyboard.composeKey = null;
   });
 
   # Test 7: Intel GPU configuration


### PR DESCRIPTION
This PR adds comprehensive documentation for the Marchyo keyboard configuration namespace to `docs/keyboard.md`. It also introduces a new `marchyo.keyboard.composeKey` option that allows users to easily configure their XKB compose key (e.g., `ralt`, `rwin`, `caps`) for typing special characters. The option propagates properly to both the system console/TTY and the Hyprland desktop environment.

---
*PR created automatically by Jules for task [8171688361638081589](https://jules.google.com/task/8171688361638081589) started by @Jylhis*