### PR TITLE
feat(tracking): aggregated multi-source weekly report with optional LLM

### DIFF
--- a/modules/home/tracking/atuin.nix
+++ b/modules/home/tracking/atuin.nix
@@ -5,6 +5,7 @@
 # which installs the system package and writes a reference /etc config.
 {
   osConfig,
+  config,
   lib,
   ...
 }:
@@ -16,9 +17,9 @@ in
   config = lib.mkIf enabled {
     programs.atuin = {
       enable = true;
-      enableBashIntegration = true;
-      enableZshIntegration = true;
-      enableFishIntegration = true;
+      enableBashIntegration = config.programs.bash.enable;
+      enableZshIntegration = config.programs.zsh.enable;
+      enableFishIntegration = config.programs.fish.enable;
       settings = {
         search_mode = "fuzzy";
         filter_mode = "global";

--- a/modules/home/tracking/atuin.nix
+++ b/modules/home/tracking/atuin.nix
@@ -17,6 +17,8 @@ in
     programs.atuin = {
       enable = true;
       enableBashIntegration = true;
+      enableZshIntegration = true;
+      enableFishIntegration = true;
       settings = {
         search_mode = "fuzzy";
         filter_mode = "global";

--- a/modules/nixos/options.nix
+++ b/modules/nixos/options.nix
@@ -922,16 +922,33 @@ in
           type = types.bool;
           default = false;
           description = ''
-            Enable local LLM-powered weekly activity analysis via llama-server
-            (llama.cpp) plus a pre-mining stage (PrefixSpan). Requires a GGUF
-            model file; expect multi-GB VRAM requirements for larger models.
+            Enable weekly aggregated activity analysis across all tracking
+            sources (shell, git, desktop, editor, file changes).
+
+            When marchyo.tracking.analysis.model is null (default), a
+            stats-only org-mode report is generated. When a GGUF model path
+            is provided, llama-server is started and the report includes an
+            AI-generated insights section.
+
+            This module is NOT auto-enabled by marchyo.tracking.enable and
+            must be opted into explicitly.
           '';
         };
 
         model = mkOption {
-          type = types.path;
+          type = types.nullOr types.path;
+          default = null;
           example = "/data/models/qwen2.5-14b-q4_k_m.gguf";
-          description = "Filesystem path to a GGUF model file for llama-server.";
+          description = ''
+            Filesystem path to a GGUF model file for llama-server.
+            When null, analysis produces a stats-only report without LLM insights.
+          '';
+        };
+
+        port = mkOption {
+          type = types.port;
+          default = 8012;
+          description = "Port for the local llama-server used by analysis.";
         };
 
         acceleration = mkOption {

--- a/modules/nixos/options.nix
+++ b/modules/nixos/options.nix
@@ -942,6 +942,31 @@ in
           description = ''
             Filesystem path to a GGUF model file for llama-server.
             When null, analysis produces a stats-only report without LLM insights.
+
+            The model must be in GGUF format (used by llama.cpp). Choose a
+            model based on your available hardware:
+
+            CPU-only (8 GB+ RAM):
+              - Qwen2.5-3B-Instruct (Q4_K_M, ~2 GB)
+              - Phi-3-mini-4k-instruct (Q4_K_M, ~2.3 GB)
+
+            GPU with 8 GB VRAM:
+              - Qwen2.5-7B-Instruct (Q4_K_M, ~4.7 GB)
+              - Mistral-7B-Instruct (Q4_K_M, ~4.4 GB)
+
+            GPU with 16 GB+ VRAM:
+              - Qwen2.5-14B-Instruct (Q4_K_M, ~8.9 GB)
+
+            Download from https://huggingface.co — search for the model name
+            with "GGUF" and pick the Q4_K_M quantisation (good balance of
+            quality and size). Example using curl:
+
+              curl -L -o ~/models/qwen2.5-7b-q4_k_m.gguf \
+                "https://huggingface.co/Qwen/Qwen2.5-7B-Instruct-GGUF/resolve/main/qwen2.5-7b-instruct-q4_k_m.gguf"
+
+            Then set:
+              marchyo.tracking.analysis.model = "/home/you/models/qwen2.5-7b-q4_k_m.gguf";
+              marchyo.tracking.analysis.acceleration = "cuda"; # if using GPU
           '';
         };
 

--- a/modules/nixos/tracking/analysis.nix
+++ b/modules/nixos/tracking/analysis.nix
@@ -128,7 +128,7 @@ let
           path = DATA_DIR / "git-activity.jsonl"
           if not path.exists():
               return {}
-          cutoff = datetime.datetime.now() - datetime.timedelta(days=DAYS)
+          cutoff = datetime.datetime.now(datetime.timezone.utc) - datetime.timedelta(days=DAYS)
           repos: dict[str, dict] = defaultdict(lambda: {"commits": 0, "branches": set(), "messages": []})
           commits_by_day: dict[str, int] = Counter()
           for line in path.read_text().splitlines():
@@ -138,7 +138,7 @@ let
                   continue
               try:
                   ts = datetime.datetime.fromisoformat(e.get("ts", ""))
-                  if ts.replace(tzinfo=None) < cutoff:
+                  if ts.replace(tzinfo=None) < cutoff.replace(tzinfo=None):
                       continue
               except (ValueError, TypeError):
                   continue
@@ -161,7 +161,7 @@ let
           path = DATA_DIR / "file-changes.jsonl"
           if not path.exists():
               return {}
-          cutoff = datetime.datetime.now() - datetime.timedelta(days=DAYS)
+          cutoff = datetime.datetime.now(datetime.timezone.utc) - datetime.timedelta(days=DAYS)
           by_dir: dict[str, int] = Counter()
           by_event: dict[str, int] = Counter()
           total = 0
@@ -172,10 +172,10 @@ let
                   continue
               try:
                   ts = datetime.datetime.fromisoformat(e.get("ts", ""))
-                  if ts < cutoff:
+                  if ts.replace(tzinfo=None) < cutoff.replace(tzinfo=None):
                       continue
               except (ValueError, TypeError):
-                  pass
+                  continue
               fpath = e.get("path", "")
               parts = pathlib.PurePosixPath(fpath).parts
               top_dir = "/".join(parts[:5]) if len(parts) >= 5 else str(pathlib.PurePosixPath(fpath).parent)
@@ -208,14 +208,22 @@ let
 
           for bucket_id, info in buckets.items():
               btype = info.get("type", "")
+              events = []
               try:
-                  events_r = requests.get(
-                      f"http://127.0.0.1:5600/api/0/buckets/{bucket_id}/events",
-                      params={"start": start, "end": end, "limit": 5000},
-                      timeout=10,
-                  )
-                  events_r.raise_for_status()
-                  events = events_r.json()
+                  page_limit = 10000
+                  offset = 0
+                  while True:
+                      events_r = requests.get(
+                          f"http://127.0.0.1:5600/api/0/buckets/{bucket_id}/events",
+                          params={"start": start, "end": end, "limit": page_limit, "offset": offset},
+                          timeout=30,
+                      )
+                      events_r.raise_for_status()
+                      page = events_r.json()
+                      events.extend(page)
+                      if len(page) < page_limit:
+                          break
+                      offset += page_limit
               except Exception:
                   continue
 
@@ -224,7 +232,6 @@ let
                       dur = ev.get("duration", 0)
                       app = ev.get("data", {}).get("app", "unknown")
                       app_durations[app] += dur
-                      total_active += dur
               elif "afk" in btype:
                   for ev in events:
                       dur = ev.get("duration", 0)

--- a/modules/nixos/tracking/analysis.nix
+++ b/modules/nixos/tracking/analysis.nix
@@ -1,10 +1,15 @@
-# Weekly activity analysis: llama-server (llama.cpp) + PrefixSpan + LLM report.
+# Weekly activity analysis: aggregated multi-source report + optional LLM insights.
 #
 # Runs a Python script on a weekly user timer that:
-#   1. Tokenises recent atuin history into per-session command sequences
-#   2. Mines frequent sub-sequences via PrefixSpan
-#   3. Sends only the aggregated patterns (never raw history) to a local
-#      llama-server instance for automation suggestions, written as an org-mode file.
+#   1. Loads data from all enabled tracking collectors (atuin, git, file
+#      changes, ActivityWatch, wakapi)
+#   2. Produces a structured stats-only org-mode report
+#   3. Optionally sends the aggregated stats to a local llama-server for
+#      automation suggestions and productivity insights
+#
+# When marchyo.tracking.analysis.model is null (default), the report is
+# stats-only. When a GGUF model path is provided, llama-server is started
+# and the report includes an AI Insights section.
 {
   config,
   lib,
@@ -14,6 +19,7 @@
 let
   cfg = config.marchyo.tracking;
   aCfg = cfg.analysis;
+  llmEnabled = aCfg.model != null;
 
   llamaCppPackage =
     if aCfg.acceleration == "cuda" then
@@ -32,13 +38,21 @@ let
     executable = true;
     text = ''
       #!${pythonEnv}/bin/python
-      """Weekly activity analysis: mine shell command patterns, let a local
-      LLM interpret them. Output is an org-mode report under ~/org/."""
-      import sqlite3, datetime, pathlib, os, time, requests
+      """Weekly activity analysis: aggregate all tracking sources into an
+      org-mode report. Optionally enriched with local LLM insights."""
+      import sqlite3, datetime, pathlib, os, time, json, requests
+      from collections import Counter, defaultdict
 
-      ATUIN_DB = pathlib.Path.home() / ".local/share/atuin/history.db"
-      REPORT   = pathlib.Path.home() / "org/activity-report.org"
-      LLAMA    = "http://127.0.0.1:8012/completion"
+      ATUIN_DB   = pathlib.Path.home() / ".local/share/atuin/history.db"
+      REPORT     = pathlib.Path.home() / "org/activity-report.org"
+      DATA_DIR   = pathlib.Path.home() / os.environ.get("MARCHYO_DATA_DIR", ".local/share/personal-data")
+      WAKAPI_PORT = int(os.environ.get("MARCHYO_WAKAPI_PORT", "3000"))
+      LLM_ENABLED = os.environ.get("MARCHYO_LLM_ENABLED", "0") == "1"
+      LLAMA_PORT  = int(os.environ.get("MARCHYO_LLAMA_PORT", "${toString aCfg.port}"))
+      LLAMA_URL   = f"http://127.0.0.1:{LLAMA_PORT}/completion"
+      DAYS        = 7
+
+      # ── Shell history (atuin) ──────────────────────────────────────────
 
       def tokenize(cmd: str) -> str:
           parts = cmd.strip().split()
@@ -48,29 +62,44 @@ let
               return f"{parts[0]}_{parts[1]}"
           return parts[0]
 
-      def load_sessions(days: int = 7):
+      def load_sessions(days: int = DAYS):
           if not ATUIN_DB.exists():
-              return []
+              return [], {}
           cutoff = int((datetime.datetime.now() - datetime.timedelta(days=days)).timestamp() * 1e9)
-          # Read-only open: avoids locking the active atuin daemon's DB and
-          # guarantees the analysis cannot modify history.
           con = sqlite3.connect(f"file:{ATUIN_DB}?mode=ro", uri=True)
           try:
               rows = con.execute(
-                  "SELECT session, command FROM history WHERE timestamp > ? ORDER BY timestamp",
+                  "SELECT session, command, exit_status, duration FROM history WHERE timestamp > ? ORDER BY timestamp",
                   (cutoff,),
               ).fetchall()
           finally:
               con.close()
           sessions: dict[str, list[str]] = {}
-          for sess, cmd in rows:
+          raw_cmds: list[str] = []
+          total_duration = 0
+          failed = 0
+          for sess, cmd, exit_status, duration in rows:
               sessions.setdefault(sess, []).append(tokenize(cmd))
-          return list(sessions.values())
+              raw_cmds.append(cmd.strip().split()[0] if cmd.strip() else "empty")
+              if exit_status and exit_status != 0:
+                  failed += 1
+              if duration:
+                  total_duration += duration
+          cmd_counts = Counter(raw_cmds)
+          stats = {
+              "total_commands": len(rows),
+              "unique_commands": len(set(raw_cmds)),
+              "sessions": len(sessions),
+              "failed": failed,
+              "total_duration_ns": total_duration,
+              "top_commands": cmd_counts.most_common(15),
+          }
+          return list(sessions.values()), stats
+
+      # ── PrefixSpan ────────────────────────────────────────────────────
 
       def _prefixspan(sequences, min_support):
-          """Inline PrefixSpan frequent subsequence mining."""
           results = []
-
           def _mine(prefix, db):
               counts = {}
               for seq in db:
@@ -85,38 +114,285 @@ let
                       results.append((count, new_prefix))
                       projected = [seq[seq.index(item) + 1:] for seq in db if item in seq]
                       _mine(new_prefix, projected)
-
           _mine([], sequences)
           return results
 
-      def mine(sessions, min_support: int = 5, min_len: int = 2):
+      def mine_patterns(sessions, min_support: int = 5, min_len: int = 2):
           if not sessions:
               return []
           return [p for p in _prefixspan(sessions, min_support) if len(p[1]) >= min_len]
 
-      def ask_llm(patterns) -> str:
-          if not patterns:
-              return "* No frequent patterns found this week.\n"
-          top = sorted(patterns, reverse=True)[:20]
-          pattern_text = "\n".join(
-              f"{i+1}. [{count} times] {' \u2192 '.join(seq)}"
-              for i, (count, seq) in enumerate(top)
-          )
+      # ── Git activity ──────────────────────────────────────────────────
+
+      def load_git_activity():
+          path = DATA_DIR / "git-activity.jsonl"
+          if not path.exists():
+              return {}
+          cutoff = datetime.datetime.now() - datetime.timedelta(days=DAYS)
+          repos: dict[str, dict] = defaultdict(lambda: {"commits": 0, "branches": set(), "messages": []})
+          commits_by_day: dict[str, int] = Counter()
+          for line in path.read_text().splitlines():
+              try:
+                  e = json.loads(line)
+              except json.JSONDecodeError:
+                  continue
+              try:
+                  ts = datetime.datetime.fromisoformat(e.get("ts", ""))
+                  if ts.replace(tzinfo=None) < cutoff:
+                      continue
+              except (ValueError, TypeError):
+                  continue
+              repo = e.get("repo", "unknown")
+              repos[repo]["commits"] += 1
+              repos[repo]["branches"].add(e.get("branch", ""))
+              repos[repo]["messages"].append(e.get("msg", ""))
+              commits_by_day[ts.strftime("%A")] += 1
+          for r in repos.values():
+              r["branches"] = list(r["branches"])
+          return {
+              "repos": dict(repos),
+              "total_commits": sum(r["commits"] for r in repos.values()),
+              "commits_by_day": dict(commits_by_day),
+          }
+
+      # ── File changes ──────────────────────────────────────────────────
+
+      def load_file_changes():
+          path = DATA_DIR / "file-changes.jsonl"
+          if not path.exists():
+              return {}
+          cutoff = datetime.datetime.now() - datetime.timedelta(days=DAYS)
+          by_dir: dict[str, int] = Counter()
+          by_event: dict[str, int] = Counter()
+          total = 0
+          for line in path.read_text().splitlines():
+              try:
+                  e = json.loads(line)
+              except json.JSONDecodeError:
+                  continue
+              try:
+                  ts = datetime.datetime.fromisoformat(e.get("ts", ""))
+                  if ts < cutoff:
+                      continue
+              except (ValueError, TypeError):
+                  pass
+              fpath = e.get("path", "")
+              parts = pathlib.PurePosixPath(fpath).parts
+              top_dir = "/".join(parts[:5]) if len(parts) >= 5 else str(pathlib.PurePosixPath(fpath).parent)
+              by_dir[top_dir] += 1
+              by_event[e.get("event", "unknown")] += 1
+              total += 1
+          return {
+              "total": total,
+              "top_directories": Counter(by_dir).most_common(10),
+              "by_event": dict(by_event),
+          }
+
+      # ── ActivityWatch ──────────────────────────────────────────────────
+
+      def load_activitywatch():
+          try:
+              r = requests.get("http://127.0.0.1:5600/api/0/buckets", timeout=5)
+              r.raise_for_status()
+              buckets = r.json()
+          except Exception:
+              return {}
+
+          now = datetime.datetime.now(datetime.timezone.utc)
+          start = (now - datetime.timedelta(days=DAYS)).isoformat()
+          end = now.isoformat()
+
+          app_durations: dict[str, float] = Counter()
+          total_active = 0.0
+          total_idle = 0.0
+
+          for bucket_id, info in buckets.items():
+              btype = info.get("type", "")
+              try:
+                  events_r = requests.get(
+                      f"http://127.0.0.1:5600/api/0/buckets/{bucket_id}/events",
+                      params={"start": start, "end": end, "limit": 5000},
+                      timeout=10,
+                  )
+                  events_r.raise_for_status()
+                  events = events_r.json()
+              except Exception:
+                  continue
+
+              if "window" in btype:
+                  for ev in events:
+                      dur = ev.get("duration", 0)
+                      app = ev.get("data", {}).get("app", "unknown")
+                      app_durations[app] += dur
+                      total_active += dur
+              elif "afk" in btype:
+                  for ev in events:
+                      dur = ev.get("duration", 0)
+                      status = ev.get("data", {}).get("status", "")
+                      if status == "not-afk":
+                          total_active += dur
+                      else:
+                          total_idle += dur
+
+          return {
+              "top_apps": Counter(app_durations).most_common(10),
+              "active_hours": round(total_active / 3600, 1),
+              "idle_hours": round(total_idle / 3600, 1),
+          }
+
+      # ── Wakapi ─────────────────────────────────────────────────────────
+
+      def load_wakapi():
+          try:
+              end = datetime.date.today()
+              start = end - datetime.timedelta(days=DAYS)
+              r = requests.get(
+                  f"http://127.0.0.1:{WAKAPI_PORT}/api/summary",
+                  params={"from": start.isoformat(), "to": end.isoformat()},
+                  timeout=10,
+              )
+              r.raise_for_status()
+              data = r.json()
+          except Exception:
+              return {}
+
+          def extract_top(items, key="name"):
+              return [(e.get(key, "?"), round(e.get("total_seconds", 0) / 3600, 1)) for e in items[:10]]
+
+          return {
+              "total_hours": round(data.get("cumulative_total", {}).get("seconds", 0) / 3600, 1),
+              "projects": extract_top(data.get("projects", [])),
+              "languages": extract_top(data.get("languages", [])),
+              "editors": extract_top(data.get("editors", [])),
+          }
+
+      # ── Report generation ─────────────────────────────────────────────
+
+      def fmt_duration_ns(ns: int) -> str:
+          secs = ns // 1_000_000_000
+          hrs, rem = divmod(secs, 3600)
+          mins = rem // 60
+          if hrs:
+              return f"{hrs}h {mins}m"
+          return f"{mins}m"
+
+      def section_shell(stats: dict, patterns: list) -> str:
+          if not stats:
+              return "* Shell Activity\nNo shell history found.\n\n"
+          lines = [
+              "* Shell Activity",
+              f"- Commands executed: {stats['total_commands']}",
+              f"- Unique commands: {stats['unique_commands']}",
+              f"- Sessions: {stats['sessions']}",
+              f"- Failed commands: {stats['failed']}",
+              f"- Total command time: {fmt_duration_ns(stats['total_duration_ns'])}",
+              "",
+              "** Top Commands",
+          ]
+          for cmd, count in stats["top_commands"]:
+              lines.append(f"| {cmd} | {count} |")
+          lines.append("")
+          if patterns:
+              top = sorted(patterns, reverse=True)[:15]
+              lines.append("** Frequent Sequences")
+              for count, seq in top:
+                  lines.append(f"- [{count}x] {' -> '.join(seq)}")
+          lines.append("")
+          return "\n".join(lines) + "\n"
+
+      def section_git(data: dict) -> str:
+          if not data or not data.get("repos"):
+              return "* Git Activity\nNo git activity recorded.\n\n"
+          lines = [
+              "* Git Activity",
+              f"- Total commits: {data['total_commits']}",
+              "",
+              "** By Repository",
+          ]
+          for repo, info in sorted(data["repos"].items(), key=lambda x: -x[1]["commits"]):
+              branches = ", ".join(b for b in info["branches"] if b)
+              lines.append(f"*** {repo} ({info['commits']} commits)")
+              if branches:
+                  lines.append(f"- Branches: {branches}")
+              for msg in info["messages"][:5]:
+                  lines.append(f"- {msg}")
+          if data.get("commits_by_day"):
+              lines.append("")
+              lines.append("** Commits by Day")
+              for day, count in sorted(data["commits_by_day"].items(), key=lambda x: -x[1]):
+                  lines.append(f"| {day} | {count} |")
+          lines.append("")
+          return "\n".join(lines) + "\n"
+
+      def section_desktop(data: dict) -> str:
+          if not data:
+              return "* Desktop Focus\nActivityWatch not available.\n\n"
+          lines = [
+              "* Desktop Focus",
+              f"- Active: {data.get('active_hours', 0)}h",
+              f"- Idle: {data.get('idle_hours', 0)}h",
+              "",
+              "** Top Applications",
+          ]
+          for app, dur in data.get("top_apps", []):
+              lines.append(f"| {app} | {round(dur / 3600, 1)}h |")
+          lines.append("")
+          return "\n".join(lines) + "\n"
+
+      def section_editor(data: dict) -> str:
+          if not data:
+              return "* Editor Activity\nWakapi not available.\n\n"
+          lines = [
+              "* Editor Activity",
+              f"- Total coding time: {data.get('total_hours', 0)}h",
+          ]
+          if data.get("projects"):
+              lines.append("")
+              lines.append("** Top Projects")
+              for name, hrs in data["projects"]:
+                  lines.append(f"| {name} | {hrs}h |")
+          if data.get("languages"):
+              lines.append("")
+              lines.append("** Top Languages")
+              for name, hrs in data["languages"]:
+                  lines.append(f"| {name} | {hrs}h |")
+          lines.append("")
+          return "\n".join(lines) + "\n"
+
+      def section_files(data: dict) -> str:
+          if not data or not data.get("total"):
+              return "* File Changes\nNo file changes recorded.\n\n"
+          lines = [
+              "* File Changes",
+              f"- Total events: {data['total']}",
+          ]
+          if data.get("by_event"):
+              lines.append("- Breakdown: " + ", ".join(f"{k}: {v}" for k, v in data["by_event"].items()))
+          if data.get("top_directories"):
+              lines.append("")
+              lines.append("** Most Active Directories")
+              for d, count in data["top_directories"]:
+                  lines.append(f"| {d} | {count} |")
+          lines.append("")
+          return "\n".join(lines) + "\n"
+
+      # ── LLM ────────────────────────────────────────────────────────────
+
+      def ask_llm(summary_text: str) -> str:
           prompt = (
-              "You are analysing a developer's shell command patterns from the past week.\n\n"
-              "## Pre-mined frequent command sequences:\n"
-              f"{pattern_text}\n\n"
-              "For each pattern that represents a real workflow (not noise):\n"
-              "1. Name the workflow\n"
-              "2. Write a shell function or script that automates it\n"
-              "3. Estimate weekly time savings in minutes\n"
-              "4. Flag if this should become a Nix-packaged tool instead.\n\n"
+              "You are analysing a developer's weekly activity data.\n\n"
+              f"{summary_text}\n\n"
+              "Based on this data:\n"
+              "1. Identify the main workflows and how time was distributed\n"
+              "2. Spot repeated command sequences that could be automated — write shell functions\n"
+              "3. Flag any anomalies (unusual hours, high failure rates, context switching)\n"
+              "4. Suggest concrete productivity improvements\n\n"
               "Output in org-mode with * headlines and #+begin_src bash blocks.\n"
           )
           for attempt in range(3):
               try:
                   r = requests.post(
-                      LLAMA,
+                      LLAMA_URL,
                       json={
                           "prompt": prompt,
                           "stream": False,
@@ -131,20 +407,37 @@ let
                   if attempt < 2:
                       time.sleep(10)
                       continue
-                  return "* LLM call failed: llama-server not reachable after 3 attempts\n"
+                  return "* LLM unreachable after 3 attempts\n"
               except Exception as exc:
                   return f"* LLM call failed: {exc}\n"
 
+      # ── Main ────────────────────────────────────────────────────────────
+
       def main() -> None:
-          sessions = load_sessions(days=7)
-          patterns = mine(sessions)
-          report = ask_llm(patterns)
-          REPORT.parent.mkdir(parents=True, exist_ok=True)
-          header = (
+          sessions, shell_stats = load_sessions()
+          patterns = mine_patterns(sessions)
+          git_data = load_git_activity()
+          file_data = load_file_changes()
+          aw_data = load_activitywatch()
+          wakapi_data = load_wakapi()
+
+          report_parts = [
               f"#+TITLE: Activity Report {datetime.date.today()}\n"
-              f"#+DATE: {datetime.datetime.now().isoformat()}\n\n"
-          )
-          REPORT.write_text(header + report)
+              f"#+DATE: {datetime.datetime.now().isoformat()}\n",
+              section_shell(shell_stats, patterns),
+              section_git(git_data),
+              section_desktop(aw_data),
+              section_editor(wakapi_data),
+              section_files(file_data),
+          ]
+
+          if LLM_ENABLED:
+              stats_text = "\n".join(report_parts[1:])
+              llm_report = ask_llm(stats_text)
+              report_parts.append("* AI Insights\n" + llm_report + "\n")
+
+          REPORT.parent.mkdir(parents=True, exist_ok=True)
+          REPORT.write_text("\n".join(report_parts))
 
       if __name__ == "__main__":
           main()
@@ -152,38 +445,50 @@ let
   };
 in
 {
-  config = lib.mkIf (cfg.enable && aCfg.enable) {
-    systemd.services.marchyo-llama-server = {
-      description = "llama-server for marchyo tracking analysis";
-      wantedBy = [ "multi-user.target" ];
-      serviceConfig = {
-        Type = "simple";
-        ExecStart = "${llamaCppPackage}/bin/llama-server -m ${aCfg.model} --host 127.0.0.1 --port 8012 -c 8192";
-        Restart = "on-failure";
-        RestartSec = 5;
-        DynamicUser = true;
-        ProtectSystem = "strict";
-        ProtectHome = "read-only";
-        NoNewPrivileges = true;
-      };
-    };
+  config = lib.mkIf (cfg.enable && aCfg.enable) (
+    lib.mkMerge [
+      {
+        systemd.user.services.marchyo-tracking-weekly-analysis = {
+          description = "Marchyo tracking: weekly activity analysis";
+          serviceConfig = {
+            Type = "oneshot";
+            ExecStart = "${analysisScript}";
+          };
+          environment = {
+            MARCHYO_DATA_DIR = cfg.dataDir;
+            MARCHYO_WAKAPI_PORT = toString cfg.editor.port;
+            MARCHYO_LLM_ENABLED = if llmEnabled then "1" else "0";
+            MARCHYO_LLAMA_PORT = toString aCfg.port;
+          };
+        };
 
-    systemd.user.services.marchyo-tracking-weekly-analysis = {
-      description = "Marchyo tracking: weekly activity analysis";
-      serviceConfig = {
-        Type = "oneshot";
-        ExecStart = "${analysisScript}";
-      };
-    };
+        systemd.user.timers.marchyo-tracking-weekly-analysis = {
+          description = "Marchyo tracking: weekly analysis timer";
+          wantedBy = [ "timers.target" ];
+          timerConfig = {
+            OnCalendar = "Sun *-*-* 09:00:00";
+            Persistent = true;
+            Unit = "marchyo-tracking-weekly-analysis.service";
+          };
+        };
+      }
 
-    systemd.user.timers.marchyo-tracking-weekly-analysis = {
-      description = "Marchyo tracking: weekly analysis timer";
-      wantedBy = [ "timers.target" ];
-      timerConfig = {
-        OnCalendar = "Sun *-*-* 09:00:00";
-        Persistent = true;
-        Unit = "marchyo-tracking-weekly-analysis.service";
-      };
-    };
-  };
+      (lib.mkIf llmEnabled {
+        systemd.services.marchyo-llama-server = {
+          description = "llama-server for marchyo tracking analysis";
+          wantedBy = [ "multi-user.target" ];
+          serviceConfig = {
+            Type = "simple";
+            ExecStart = "${llamaCppPackage}/bin/llama-server -m ${aCfg.model} --host 127.0.0.1 --port ${toString aCfg.port} -c 8192";
+            Restart = "on-failure";
+            RestartSec = 5;
+            DynamicUser = true;
+            ProtectSystem = "strict";
+            ProtectHome = "read-only";
+            NoNewPrivileges = true;
+          };
+        };
+      })
+    ]
+  );
 }

--- a/modules/nixos/tracking/default.nix
+++ b/modules/nixos/tracking/default.nix
@@ -25,7 +25,8 @@ in
       system.auditd = lib.mkDefault true;
       system.fileWatch = lib.mkDefault true;
       aggregation.enable = lib.mkDefault true;
-      analysis.enable = lib.mkDefault true;
+      # analysis.enable is deliberately left out: it requires explicit opt-in
+      # because it pulls in a Python env and optionally llama.cpp.
       # desktop.screenshots.enable is deliberately left false
     };
   };

--- a/modules/nixos/tracking/system.nix
+++ b/modules/nixos/tracking/system.nix
@@ -17,9 +17,12 @@ let
     WATCH_DIRS=()
     [ -d "$HOME/Developer" ] && WATCH_DIRS+=("$HOME/Developer")
     [ -d "$HOME/.config" ]   && WATCH_DIRS+=("$HOME/.config")
-    if [ ''${#WATCH_DIRS[@]} -eq 0 ]; then
-      exec ${pkgs.coreutils}/bin/sleep infinity
-    fi
+    while [ ''${#WATCH_DIRS[@]} -eq 0 ]; do
+      ${pkgs.coreutils}/bin/sleep 60
+      WATCH_DIRS=()
+      [ -d "$HOME/Developer" ] && WATCH_DIRS+=("$HOME/Developer")
+      [ -d "$HOME/.config" ]   && WATCH_DIRS+=("$HOME/.config")
+    done
     exec ${pkgs.inotify-tools}/bin/inotifywait -m -r \
       --exclude '(\.git|node_modules|target|__pycache__|\.cache|result|\.direnv)' \
       -e close_write,create,delete,moved_to \

--- a/tests/module-tests.nix
+++ b/tests/module-tests.nix
@@ -298,7 +298,7 @@ in
     marchyo.users.testuser.wakatimeApiKey = "waka_test_00000000-0000-0000-0000-000000000000";
   });
 
-  # Tracking: analysis module (exercises inline PrefixSpan + Ollama wiring)
+  # Tracking: analysis module — stats-only (no model)
   eval-tracking-analysis = testNixOS "tracking-analysis" (withTestUser {
     marchyo.tracking = {
       enable = true;
@@ -351,6 +351,20 @@ in
         plugins.emacs.enable = true;
       };
     };
+  });
+
+  # Tracking: analysis module — with LLM model configured
+  eval-tracking-analysis-with-model = testNixOS "tracking-analysis-model" (withTestUser {
+    marchyo.tracking = {
+      enable = true;
+      analysis.enable = true;
+      analysis.model = "/data/models/test.gguf";
+    };
+  });
+
+  # Tracking: full cascade does NOT auto-enable analysis
+  eval-tracking-no-auto-analysis = testNixOS "tracking-no-auto-analysis" (withTestUser {
+    marchyo.tracking.enable = true;
   });
   # Test 19: Jotain as externally-managed editor (no package installed by marchyo)
   eval-defaults-jotain = testNixOS "defaults-jotain" (withTestUser {


### PR DESCRIPTION
Replace the shell-only analysis script with a comprehensive report that
ingests all tracking collectors: atuin shell history, git activity JSONL,
file changes JSONL, ActivityWatch REST API, and wakapi REST API.

- Stats-only org-mode report is generated by default (no model needed)
- LLM insights appended when analysis.model is set (llama-server starts
  conditionally)
- analysis.model changed to nullOr types.path with default null
- analysis.enable removed from tracking cascade (opt-in only)
- Add analysis.port option (default 8012, was hardcoded)
- Add tests for stats-only, with-model, and cascade-no-analysis cases

https://claude.ai/code/session_01KeXbUQ9uqF2pMLSBncUNxU