### PR TITLE
feat(tracking): add per-plugin enable options for editor tracking

### DIFF
--- a/modules/nixos/options.nix
+++ b/modules/nixos/options.nix
@@ -716,6 +716,74 @@ in
           default = 3000;
           description = "Port for the local wakapi service.";
         };
+
+        plugins = {
+          brave.enable = mkOption {
+            type = types.bool;
+            default = false;
+            description = "Enable WakaTime tracking for Brave browser.";
+          };
+
+          chrome.enable = mkOption {
+            type = types.bool;
+            default = false;
+            description = "Enable WakaTime tracking for Google Chrome.";
+          };
+
+          chromium.enable = mkOption {
+            type = types.bool;
+            default = false;
+            description = "Enable WakaTime tracking for Chromium.";
+          };
+
+          firefox.enable = mkOption {
+            type = types.bool;
+            default = false;
+            description = "Enable WakaTime tracking for Firefox.";
+          };
+
+          emacs.enable = mkOption {
+            type = types.bool;
+            default = false;
+            description = "Enable WakaTime tracking for Emacs via wakatime-mode.";
+          };
+
+          vscode.enable = mkOption {
+            type = types.bool;
+            default = false;
+            description = "Enable WakaTime tracking for VS Code.";
+          };
+
+          vscodium.enable = mkOption {
+            type = types.bool;
+            default = false;
+            description = "Enable WakaTime tracking for VS Codium.";
+          };
+
+          neovim.enable = mkOption {
+            type = types.bool;
+            default = false;
+            description = "Enable WakaTime tracking for Neovim via vim-wakatime.";
+          };
+
+          vim.enable = mkOption {
+            type = types.bool;
+            default = false;
+            description = "Enable WakaTime tracking for Vim via vim-wakatime.";
+          };
+
+          helix.enable = mkOption {
+            type = types.bool;
+            default = false;
+            description = "Enable WakaTime tracking for Helix.";
+          };
+
+          zed.enable = mkOption {
+            type = types.bool;
+            default = false;
+            description = "Enable WakaTime tracking for Zed.";
+          };
+        };
       };
 
       git = {

--- a/modules/nixos/tracking/editor.nix
+++ b/modules/nixos/tracking/editor.nix
@@ -12,6 +12,7 @@
 let
   cfg = config.marchyo.tracking;
   editorCfg = cfg.editor;
+  d = config.marchyo.defaults;
 in
 {
   config = lib.mkIf (cfg.enable && editorCfg.enable) {
@@ -29,6 +30,29 @@ in
         };
         db.dialect = "sqlite3";
       };
+    };
+
+    marchyo.tracking.editor.plugins = {
+      brave.enable = lib.mkDefault (d.browser == "brave");
+      chrome.enable = lib.mkDefault (d.browser == "google-chrome");
+      chromium.enable = lib.mkDefault (
+        d.browser == "chromium" || config.programs.chromium.enable or false
+      );
+      firefox.enable = lib.mkDefault (d.browser == "firefox" || config.programs.firefox.enable or false);
+      emacs.enable = lib.mkDefault (
+        d.editor == "emacs"
+        || d.terminalEditor == "emacs"
+        || config.services.emacs.enable or false
+        || config.programs.emacs.enable or false
+      );
+      vscode.enable = lib.mkDefault (d.editor == "vscode");
+      vscodium.enable = lib.mkDefault (d.editor == "vscodium");
+      neovim.enable = lib.mkDefault (
+        d.terminalEditor == "neovim" || config.programs.neovim.enable or false
+      );
+      vim.enable = lib.mkDefault (config.programs.vim.enable or false);
+      helix.enable = lib.mkDefault (d.terminalEditor == "helix" || config.programs.helix.enable or false);
+      zed.enable = lib.mkDefault (d.editor == "zed");
     };
   };
 }

--- a/tests/module-tests.nix
+++ b/tests/module-tests.nix
@@ -329,6 +329,29 @@ in
     }
   );
 
+  # Tracking: editor plugins auto-detect from defaults
+  eval-tracking-editor-plugins = testNixOS "tracking-editor-plugins" (withTestUser {
+    marchyo.tracking = {
+      enable = true;
+      editor.enable = true;
+    };
+    marchyo.desktop.enable = true;
+    marchyo.defaults.browser = "firefox";
+    marchyo.defaults.editor = "vscode";
+    marchyo.defaults.terminalEditor = "neovim";
+  });
+
+  # Tracking: editor plugins with explicit overrides
+  eval-tracking-editor-plugins-override = testNixOS "tracking-editor-plugins-override" (withTestUser {
+    marchyo.tracking = {
+      enable = true;
+      editor = {
+        enable = true;
+        plugins.chrome.enable = true;
+        plugins.emacs.enable = true;
+      };
+    };
+  });
   # Test 19: Jotain as externally-managed editor (no package installed by marchyo)
   eval-defaults-jotain = testNixOS "defaults-jotain" (withTestUser {
     marchyo.desktop.enable = true;


### PR DESCRIPTION
Add marchyo.tracking.editor.plugins with enable flags for 11 programs (brave, chrome, chromium, firefox, emacs, vscode, vscodium, neovim, vim, helix, zed). Each plugin auto-detects from marchyo.defaults.* and programs.*.enable via mkDefault, so users can override individually.

https://claude.ai/code/session_01KtBz4NonRCQPXdR4X7haR3