### PR TITLE
refactor(ghostty): generate tab keybinds with map instead of copy-paste

### DIFF
--- a/modules/home/ghostty.nix
+++ b/modules/home/ghostty.nix
@@ -19,17 +19,9 @@ in
       confirm-close-surface = false;
       unfocused-split-opacity = mkDefault 0.7;
       gtk-single-instance = true;
-      keybind = [
-        "alt+1=goto_tab:1"
-        "alt+2=goto_tab:2"
-        "alt+3=goto_tab:3"
-        "alt+4=goto_tab:4"
-        "alt+5=goto_tab:5"
-        "alt+6=goto_tab:6"
-        "alt+7=goto_tab:7"
-        "alt+8=goto_tab:8"
-        "alt+9=last_tab"
-      ];
+      keybind =
+        (map (n: "alt+${toString n}=goto_tab:${toString n}") (lib.range 1 8))
+        ++ [ "alt+9=last_tab" ];
     };
   };
 }


### PR DESCRIPTION
Replace 8 near-identical alt+N=goto_tab:N strings with a single map expression over lib.range, reducing the chance of copy-paste drift.

https://claude.ai/code/session_01TnLtKEyKtr5vsffcgyZFgH