### PR TITLE
feat(tracking): add Grafana Cloud sink and Claude Code OTLP telemetry

### DIFF
--- a/modules/home/tracking/claude-code.nix
+++ b/modules/home/tracking/claude-code.nix
@@ -55,30 +55,42 @@ in
     programs.zsh.initExtra = shellInit;
     programs.fish.interactiveShellInit = fishInit;
 
+    # Merge the OTEL `env` block into ~/.claude/settings.json without
+    # touching other user-managed keys (model, theme, hooks, permissions, …).
     home.activation.marchyoClaudeCodeSettings = lib.hm.dag.entryAfter [ "writeBoundary" ] ''
       header=""
       if [ -r "${authFile}" ]; then
         header=$(cat "${authFile}")
       fi
       run mkdir -p "$HOME/.claude"
-      run ${pkgs.jq}/bin/jq -n \
+      newEnv=$(${pkgs.jq}/bin/jq -nc \
         --arg ep  "${baseEnv.OTEL_EXPORTER_OTLP_ENDPOINT}" \
         --arg pr  "${baseEnv.OTEL_EXPORTER_OTLP_PROTOCOL}" \
         --arg mi  "${baseEnv.OTEL_METRIC_EXPORT_INTERVAL}" \
         --arg li  "${baseEnv.OTEL_LOGS_EXPORT_INTERVAL}" \
         --arg hdr "$header" \
         '{
-          env: ({
-            CLAUDE_CODE_ENABLE_TELEMETRY: "1",
-            OTEL_METRICS_EXPORTER: "otlp",
-            OTEL_LOGS_EXPORTER: "otlp",
-            OTEL_EXPORTER_OTLP_PROTOCOL: $pr,
-            OTEL_EXPORTER_OTLP_ENDPOINT: $ep,
-            OTEL_METRIC_EXPORT_INTERVAL: $mi,
-            OTEL_LOGS_EXPORT_INTERVAL: $li
-          } + (if $hdr == "" then {} else { OTEL_EXPORTER_OTLP_HEADERS: $hdr } end))
-        }' > "$HOME/.claude/settings.json.tmp"
-      run mv "$HOME/.claude/settings.json.tmp" "$HOME/.claude/settings.json"
+          CLAUDE_CODE_ENABLE_TELEMETRY: "1",
+          OTEL_METRICS_EXPORTER: "otlp",
+          OTEL_LOGS_EXPORTER: "otlp",
+          OTEL_EXPORTER_OTLP_PROTOCOL: $pr,
+          OTEL_EXPORTER_OTLP_ENDPOINT: $ep,
+          OTEL_METRIC_EXPORT_INTERVAL: $mi,
+          OTEL_LOGS_EXPORT_INTERVAL: $li
+        } + (if $hdr == "" then {} else { OTEL_EXPORTER_OTLP_HEADERS: $hdr } end)')
+      settings="$HOME/.claude/settings.json"
+      tmp="$settings.tmp"
+      if [ -f "$settings" ]; then
+        if ${pkgs.jq}/bin/jq --argjson env "$newEnv" '.env = ((.env // {}) + $env)' "$settings" > "$tmp"; then
+          run mv "$tmp" "$settings"
+        else
+          echo "marchyo: ~/.claude/settings.json is not valid JSON; leaving it untouched" >&2
+          rm -f "$tmp"
+        fi
+      else
+        ${pkgs.jq}/bin/jq -n --argjson env "$newEnv" '{env: $env}' > "$tmp"
+        run mv "$tmp" "$settings"
+      fi
     '';
   };
 }

--- a/modules/home/tracking/claude-code.nix
+++ b/modules/home/tracking/claude-code.nix
@@ -1,0 +1,84 @@
+# Claude Code OpenTelemetry tracking (per-user).
+#
+# When `marchyo.tracking.claudeCode.enable` is true at the system level,
+# this module:
+#   * sets the static OTEL_* / CLAUDE_CODE_ENABLE_TELEMETRY env vars via
+#     home.sessionVariables (picked up by login shells / display managers);
+#   * exports OTEL_EXPORTER_OTLP_HEADERS in interactive bash/zsh/fish
+#     sessions by reading `authHeaderFile` at shell init (so the secret
+#     never enters the Nix store);
+#   * regenerates ~/.claude/settings.json at home-manager activation,
+#     embedding the same env block (including the header read from the
+#     auth file) so launcher- and IDE-launched Claude Code sessions also
+#     get the telemetry config.
+{
+  osConfig ? { },
+  lib,
+  pkgs,
+  ...
+}:
+let
+  trackingCfg = osConfig.marchyo.tracking or { };
+  ccCfg = trackingCfg.claudeCode or { };
+  enabled = (trackingCfg.enable or false) && (ccCfg.enable or false);
+
+  authFile = toString (ccCfg.authHeaderFile or "");
+
+  baseEnv = {
+    CLAUDE_CODE_ENABLE_TELEMETRY = "1";
+    OTEL_METRICS_EXPORTER = "otlp";
+    OTEL_LOGS_EXPORTER = "otlp";
+    OTEL_EXPORTER_OTLP_PROTOCOL = ccCfg.protocol or "http/protobuf";
+    OTEL_EXPORTER_OTLP_ENDPOINT =
+      ccCfg.otlpEndpoint or "https://otlp-gateway-prod-eu-west-0.grafana.net/otlp";
+    OTEL_METRIC_EXPORT_INTERVAL = toString (ccCfg.metricExportIntervalMs or 10000);
+    OTEL_LOGS_EXPORT_INTERVAL = toString (ccCfg.logExportIntervalMs or 5000);
+  };
+
+  shellInit = ''
+    if [ -r "${authFile}" ]; then
+      export OTEL_EXPORTER_OTLP_HEADERS="$(cat "${authFile}")"
+    fi
+  '';
+
+  fishInit = ''
+    if test -r "${authFile}"
+        set -gx OTEL_EXPORTER_OTLP_HEADERS (cat "${authFile}")
+    end
+  '';
+in
+{
+  config = lib.mkIf enabled {
+    home.sessionVariables = baseEnv;
+
+    programs.bash.initExtra = shellInit;
+    programs.zsh.initExtra = shellInit;
+    programs.fish.interactiveShellInit = fishInit;
+
+    home.activation.marchyoClaudeCodeSettings = lib.hm.dag.entryAfter [ "writeBoundary" ] ''
+      header=""
+      if [ -r "${authFile}" ]; then
+        header=$(cat "${authFile}")
+      fi
+      run mkdir -p "$HOME/.claude"
+      run ${pkgs.jq}/bin/jq -n \
+        --arg ep  "${baseEnv.OTEL_EXPORTER_OTLP_ENDPOINT}" \
+        --arg pr  "${baseEnv.OTEL_EXPORTER_OTLP_PROTOCOL}" \
+        --arg mi  "${baseEnv.OTEL_METRIC_EXPORT_INTERVAL}" \
+        --arg li  "${baseEnv.OTEL_LOGS_EXPORT_INTERVAL}" \
+        --arg hdr "$header" \
+        '{
+          env: ({
+            CLAUDE_CODE_ENABLE_TELEMETRY: "1",
+            OTEL_METRICS_EXPORTER: "otlp",
+            OTEL_LOGS_EXPORTER: "otlp",
+            OTEL_EXPORTER_OTLP_PROTOCOL: $pr,
+            OTEL_EXPORTER_OTLP_ENDPOINT: $ep,
+            OTEL_METRIC_EXPORT_INTERVAL: $mi,
+            OTEL_LOGS_EXPORT_INTERVAL: $li
+          } + (if $hdr == "" then {} else { OTEL_EXPORTER_OTLP_HEADERS: $hdr } end))
+        }' > "$HOME/.claude/settings.json.tmp"
+      run mv "$HOME/.claude/settings.json.tmp" "$HOME/.claude/settings.json"
+    '';
+  };
+}

--- a/modules/home/tracking/default.nix
+++ b/modules/home/tracking/default.nix
@@ -3,6 +3,7 @@
     ../wakatime.nix
     ./atuin.nix
     ./activitywatch.nix
+    ./claude-code.nix
     ./git.nix
   ];
 }

--- a/modules/nixos/options.nix
+++ b/modules/nixos/options.nix
@@ -910,10 +910,97 @@ in
           default = null;
           example = "http://loki.internal:3100";
           description = ''
-            URL of an existing Loki ingest endpoint. When null, Vector is
-            configured with a blackhole sink (no egress) so local JSONL
-            sources still validate and can be swapped later.
+            URL of an existing self-hosted Loki ingest endpoint. When null,
+            Vector is configured with a blackhole sink (no egress) so local
+            JSONL sources still validate and can be swapped later. Mutually
+            exclusive with `aggregation.grafanaCloud.enable`.
           '';
+        };
+
+        grafanaCloud = {
+          enable = mkOption {
+            type = types.bool;
+            default = false;
+            description = ''
+              Ship Marchyo tracking data to Grafana Cloud. When true, Vector
+              forwards parsed JSONL events to Grafana Cloud Loki using basic
+              auth, and (optionally) scrapes the local node_exporter and
+              pushes host metrics to Grafana Cloud Mimir via Prometheus
+              remote_write. Credentials are read from
+              `aggregation.grafanaCloud.environmentFile` so tokens never
+              enter the Nix store.
+            '';
+          };
+
+          loki = {
+            endpoint = mkOption {
+              type = types.str;
+              example = "https://logs-prod-eu-west-0.grafana.net";
+              description = ''
+                Grafana Cloud Loki base URL (without the
+                `/loki/api/v1/push` suffix; Vector appends it).
+              '';
+            };
+
+            userId = mkOption {
+              type = types.str;
+              example = "1234567";
+              description = ''
+                Grafana Cloud Loki instance/user ID (the numeric "User"
+                shown on the "Send Logs" details page).
+              '';
+            };
+          };
+
+          prometheus = {
+            enable = mkOption {
+              type = types.bool;
+              default = false;
+              description = ''
+                Also ship host metrics to Grafana Cloud Mimir via
+                Prometheus remote_write. Enables
+                `services.prometheus.exporters.node` on 127.0.0.1:9100 and
+                wires Vector to scrape it.
+              '';
+            };
+
+            endpoint = mkOption {
+              type = types.str;
+              example = "https://prometheus-prod-24-prod-eu-west-2.grafana.net/api/prom/push";
+              description = ''
+                Grafana Cloud Mimir remote_write URL (the full path,
+                including `/api/prom/push`).
+              '';
+            };
+
+            userId = mkOption {
+              type = types.str;
+              example = "1234567";
+              description = ''
+                Grafana Cloud Mimir instance/user ID (the numeric "User"
+                shown on the "Send Metrics" details page).
+              '';
+            };
+          };
+
+          environmentFile = mkOption {
+            type = types.path;
+            example = "/var/lib/marchyo/grafana-cloud.env";
+            description = ''
+              Path to a systemd `EnvironmentFile` loaded by the Vector
+              service. Must define:
+
+                  GRAFANA_CLOUD_LOKI_TOKEN=<token>
+
+              and, when `prometheus.enable = true`:
+
+                  GRAFANA_CLOUD_PROM_TOKEN=<token>
+
+              The same Cloud Access Policy token can be used for both if
+              it has the `logs:write` and `metrics:write` scopes. The file
+              is read at service start and never enters the Nix store.
+            '';
+          };
         };
       };
 
@@ -946,6 +1033,77 @@ in
           description = ''
             Hardware acceleration backend for llama-server. When null the CPU
             build is used. Set to "cuda" or "rocm" for GPU inference.
+          '';
+        };
+      };
+
+      claudeCode = {
+        enable = mkOption {
+          type = types.bool;
+          default = false;
+          description = ''
+            Configure Claude Code to emit OpenTelemetry metrics and logs
+            to an OTLP endpoint (e.g. Grafana Cloud's OTLP gateway). For
+            every Marchyo user, writes ~/.claude/settings.json with an
+            `env` block and exports the same variables via
+            `home.sessionVariables` plus interactive shell init so both
+            launcher- and shell-started Claude Code sessions inherit the
+            telemetry config. Requires `authHeaderFile` to be set.
+          '';
+        };
+
+        otlpEndpoint = mkOption {
+          type = types.str;
+          default = "https://otlp-gateway-prod-eu-west-0.grafana.net/otlp";
+          example = "https://otlp-gateway-prod-us-east-0.grafana.net/otlp";
+          description = ''
+            Grafana Cloud OTLP gateway URL. Region-specific; pick the
+            gateway nearest to your Grafana Cloud stack.
+          '';
+        };
+
+        protocol = mkOption {
+          type = types.enum [
+            "http/protobuf"
+            "grpc"
+          ];
+          default = "http/protobuf";
+          description = ''
+            OTLP transport protocol used by Claude Code
+            (OTEL_EXPORTER_OTLP_PROTOCOL).
+          '';
+        };
+
+        authHeaderFile = mkOption {
+          type = types.path;
+          example = "/var/lib/marchyo/claude-code-otlp-auth";
+          description = ''
+            Path to a file whose contents are the value of
+            OTEL_EXPORTER_OTLP_HEADERS, e.g.
+
+                Authorization=Basic <base64(instanceId:token)>
+
+            The file is read at home-manager activation and by interactive
+            shell init; its contents never enter the Nix store. Keep it
+            readable only by the owning user (chmod 0600).
+          '';
+        };
+
+        metricExportIntervalMs = mkOption {
+          type = types.ints.positive;
+          default = 10000;
+          description = ''
+            Value for OTEL_METRIC_EXPORT_INTERVAL (milliseconds between
+            metric exports).
+          '';
+        };
+
+        logExportIntervalMs = mkOption {
+          type = types.ints.positive;
+          default = 5000;
+          description = ''
+            Value for OTEL_LOGS_EXPORT_INTERVAL (milliseconds between log
+            exports).
           '';
         };
       };

--- a/modules/nixos/tracking/aggregation.nix
+++ b/modules/nixos/tracking/aggregation.nix
@@ -3,6 +3,11 @@
 # Tails the JSONL event streams in each configured marchyo user's data
 # directory and either forwards them to a Loki endpoint or drops them into
 # a local blackhole sink when no endpoint is configured.
+#
+# When `aggregation.grafanaCloud.enable = true`, Vector forwards parsed
+# events to Grafana Cloud Loki (basic auth, token from EnvironmentFile)
+# and optionally scrapes the local node_exporter to push host metrics to
+# Grafana Cloud Mimir via Prometheus remote_write.
 {
   config,
   lib,
@@ -12,6 +17,7 @@
 let
   cfg = config.marchyo.tracking;
   aggCfg = cfg.aggregation;
+  gcCfg = aggCfg.grafanaCloud;
   mUsers = builtins.attrNames config.marchyo.users;
 
   jsonlPaths = map (u: "${config.users.users.${u}.home}/${cfg.dataDir}/*.jsonl") mUsers;
@@ -34,16 +40,44 @@ let
     read_from = "beginning";
   };
 
+  promScrapeSource = {
+    type = "prometheus_scrape";
+    endpoints = [ "http://127.0.0.1:9100/metrics" ];
+    scrape_interval_secs = 30;
+  };
+
+  metricSources = lib.optionalAttrs (gcCfg.enable && gcCfg.prometheus.enable) {
+    prom_scrape = promScrapeSource;
+  };
+
   vectorSources = {
     activity_logs = activityLogsSource;
   }
-  // lib.optionalAttrs laurelEnabled { audit_logs = auditLogsSource; };
+  // lib.optionalAttrs laurelEnabled { audit_logs = auditLogsSource; }
+  // metricSources;
 
-  lokiSink = {
+  selfHostedLokiSink = {
     type = "loki";
     inputs = [ "parse" ];
     endpoint = aggCfg.lokiEndpoint;
     encoding.codec = "json";
+    labels = {
+      source = "marchyo-tracking";
+      type = "{{ type }}";
+      host = "{{ host }}";
+    };
+  };
+
+  grafanaCloudLokiSink = {
+    type = "loki";
+    inputs = [ "parse" ];
+    inherit (gcCfg.loki) endpoint;
+    encoding.codec = "json";
+    auth = {
+      strategy = "basic";
+      user = gcCfg.loki.userId;
+      password = "\${GRAFANA_CLOUD_LOKI_TOKEN}";
+    };
     labels = {
       source = "marchyo-tracking";
       type = "{{ type }}";
@@ -56,16 +90,61 @@ let
     inputs = [ "parse" ];
     print_interval_secs = 3600;
   };
+
+  promRemoteWriteSink = {
+    type = "prometheus_remote_write";
+    inputs = [ "prom_scrape" ];
+    inherit (gcCfg.prometheus) endpoint;
+    auth = {
+      strategy = "basic";
+      user = gcCfg.prometheus.userId;
+      password = "\${GRAFANA_CLOUD_PROM_TOKEN}";
+    };
+  };
+
+  logSinks =
+    if gcCfg.enable then
+      { grafana_cloud_loki = grafanaCloudLokiSink; }
+    else if aggCfg.lokiEndpoint != null then
+      { loki = selfHostedLokiSink; }
+    else
+      { null_sink = blackholeSink; };
+
+  metricSinks = lib.optionalAttrs (gcCfg.enable && gcCfg.prometheus.enable) {
+    grafana_cloud_prom = promRemoteWriteSink;
+  };
 in
 {
   config = lib.mkIf (cfg.enable && aggCfg.enable) {
+    assertions = [
+      {
+        assertion = !(gcCfg.enable && aggCfg.lokiEndpoint != null);
+        message = ''
+          marchyo.tracking.aggregation: cannot enable both `grafanaCloud.enable`
+          and a self-hosted `lokiEndpoint`. Pick one Loki destination.
+        '';
+      }
+    ];
+
     environment.systemPackages = with pkgs; [ duckdb ];
+
+    services.prometheus.exporters.node = lib.mkIf (gcCfg.enable && gcCfg.prometheus.enable) {
+      enable = true;
+      listenAddress = "127.0.0.1";
+      port = 9100;
+      enabledCollectors = [ "systemd" ];
+    };
+
+    systemd.services.vector.serviceConfig = lib.mkIf gcCfg.enable {
+      EnvironmentFile = [ gcCfg.environmentFile ];
+    };
 
     services.vector = {
       enable = true;
       journaldAccess = true;
       settings = {
         sources = vectorSources;
+
         transforms.parse = {
           type = "remap";
           inputs = parseInputs;
@@ -74,8 +153,8 @@ in
             .host = get_hostname!()
           '';
         };
-        sinks =
-          if aggCfg.lokiEndpoint != null then { loki = lokiSink; } else { null_sink = blackholeSink; };
+
+        sinks = logSinks // metricSinks;
       };
     };
   };

--- a/modules/nixos/tracking/claude-code.nix
+++ b/modules/nixos/tracking/claude-code.nix
@@ -1,0 +1,27 @@
+# Claude Code OpenTelemetry tracking (NixOS coordinator).
+#
+# The actual configuration (settings.json + shell init) is written by
+# `modules/home/tracking/claude-code.nix` per user. This module exists to
+# keep the tracking namespace consistent and to fail the build with a
+# helpful message when the option set is incomplete.
+{ config, lib, ... }:
+let
+  cfg = config.marchyo.tracking;
+  ccCfg = cfg.claudeCode;
+in
+{
+  config = lib.mkIf (cfg.enable && ccCfg.enable) {
+    assertions = [
+      {
+        assertion = ccCfg.authHeaderFile != null && ccCfg.authHeaderFile != "";
+        message = ''
+          marchyo.tracking.claudeCode.enable = true requires
+          marchyo.tracking.claudeCode.authHeaderFile to point at a file
+          containing the OTEL_EXPORTER_OTLP_HEADERS value, e.g.
+
+              "Authorization=Basic <base64(instanceId:token)>"
+        '';
+      }
+    ];
+  };
+}

--- a/modules/nixos/tracking/default.nix
+++ b/modules/nixos/tracking/default.nix
@@ -12,6 +12,7 @@ in
     ./laurel.nix
     ./aggregation.nix
     ./analysis.nix
+    ./claude-code.nix
   ];
 
   # When tracking is enabled, auto-enable all collectors except screenshots.

--- a/tests/module-tests.nix
+++ b/tests/module-tests.nix
@@ -352,6 +352,41 @@ in
       };
     };
   });
+
+  # Tracking: Grafana Cloud aggregation (Loki + Prometheus remote_write)
+  eval-tracking-grafana-cloud = testNixOS "tracking-grafana-cloud" (withTestUser {
+    marchyo.tracking = {
+      enable = true;
+      aggregation = {
+        enable = true;
+        grafanaCloud = {
+          enable = true;
+          loki = {
+            endpoint = "https://logs-prod-eu-west-0.grafana.net";
+            userId = "1234567";
+          };
+          prometheus = {
+            enable = true;
+            endpoint = "https://prometheus-prod-24-prod-eu-west-2.grafana.net/api/prom/push";
+            userId = "1234567";
+          };
+          environmentFile = "/var/lib/marchyo/grafana-cloud.env";
+        };
+      };
+    };
+  });
+
+  # Tracking: Claude Code OTLP telemetry to Grafana Cloud
+  eval-tracking-claude-code = testNixOS "tracking-claude-code" (withTestUser {
+    marchyo.tracking = {
+      enable = true;
+      claudeCode = {
+        enable = true;
+        authHeaderFile = "/var/lib/marchyo/claude-code-otlp-auth";
+      };
+    };
+  });
+
   # Test 19: Jotain as externally-managed editor (no package installed by marchyo)
   eval-defaults-jotain = testNixOS "defaults-jotain" (withTestUser {
     marchyo.desktop.enable = true;


### PR DESCRIPTION
Two opt-in additions to `marchyo.tracking.*`:

- `aggregation.grafanaCloud` — ship Vector-parsed JSONL streams to
  Grafana Cloud Loki (basic auth) and, optionally, host metrics from
  node_exporter to Grafana Cloud Mimir via Prometheus remote_write.
  Credentials are loaded from a systemd EnvironmentFile so tokens
  never enter the Nix store. Mutually exclusive with the existing
  self-hosted `aggregation.lokiEndpoint`.

- `claudeCode` — configure Claude Code's built-in OpenTelemetry
  exporter (CLAUDE_CODE_ENABLE_TELEMETRY + OTEL_*) to ship metrics
  and logs directly to a Grafana Cloud OTLP gateway. Per the Quesma
  guide. Home Manager writes ~/.claude/settings.json on activation
  (pulling the auth header from a file outside the Nix store) and
  also exports the env vars via home.sessionVariables and bash/zsh/
  fish init fragments for shell-launched sessions.

Both features are off by default; enabling `marchyo.tracking.enable`
does not auto-enable them since they require external credentials.