### PR TITLE
refactor(ghostty): generate tab keybindings with lib.range

### DIFF
--- a/modules/home/ghostty.nix
+++ b/modules/home/ghostty.nix
@@ -19,17 +19,9 @@ in
       confirm-close-surface = false;
       unfocused-split-opacity = mkDefault 0.7;
       gtk-single-instance = true;
-      keybind = [
-        "alt+1=goto_tab:1"
-        "alt+2=goto_tab:2"
-        "alt+3=goto_tab:3"
-        "alt+4=goto_tab:4"
-        "alt+5=goto_tab:5"
-        "alt+6=goto_tab:6"
-        "alt+7=goto_tab:7"
-        "alt+8=goto_tab:8"
-        "alt+9=last_tab"
-      ];
+      keybind =
+        (map (n: "alt+${toString n}=goto_tab:${toString n}") (lib.range 1 8))
+        ++ [ "alt+9=last_tab" ];
     };
   };
 }


### PR DESCRIPTION
Replace 8 hand-written alt+N=goto_tab:N lines with a map over lib.range 1 8, keeping the alt+9=last_tab special case explicit.

https://claude.ai/code/session_01TEFRDx2JJwQAyeZDGTgv1A