### PR TITLE
docs: migrate mint.json to docs.json format

### DIFF
--- a/docs/docs.json
+++ b/docs/docs.json
@@ -1,19 +1,11 @@
 {
-  "$schema": "https://mintlify.com/schema.json",
+  "$schema": "https://mintlify.com/docs.json",
+  "theme": "mint",
   "name": "Marchyo",
-  "logo": {
-    "dark": "/logo/dark.svg",
-    "light": "/logo/light.svg"
-  },
-  "favicon": "/favicon.svg",
   "colors": {
     "primary": "#5E81AC",
     "light": "#88C0D0",
-    "dark": "#2E3440",
-    "anchors": {
-      "from": "#5E81AC",
-      "to": "#88C0D0"
-    }
+    "dark": "#2E3440"
   },
   "navigation": [
     {
@@ -53,7 +45,9 @@
       ]
     }
   ],
-  "footerSocials": {
-    "github": "https://github.com/Jylhis/marchyo"
+  "footer": {
+    "socials": {
+      "github": "https://github.com/Jylhis/marchyo"
+    }
   }
 }


### PR DESCRIPTION
Update to the modern Mintlify docs.json schema. Drop logo, favicon, and color anchors (stripped by the aggregation pipeline anyway) and rename footerSocials to footer.socials.

https://claude.ai/code/session_01LGH1JJn4PYwmwDC6hk748R