### PR TITLE
ci: split PR and main runs; defer Darwin builds to release tags

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,0 +1,47 @@
+name: Release builds
+on:
+  push:
+    tags: ['v*']
+  workflow_dispatch:
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: false
+permissions:
+  contents: read
+jobs:
+  build-nixos-x86:
+    name: Build NixOS (x86_64-linux)
+    runs-on: ubuntu-latest
+    timeout-minutes: 60
+    steps:
+      - uses: actions/checkout@v6
+      - uses: cachix/install-nix-action@v31
+      - uses: cachix/cachix-action@v17
+        with:
+          name: jylhis
+          authToken: '${{ secrets.CACHIX_AUTH_TOKEN }}'
+      - run: nix build --accept-flake-config .#nixosConfigurations.x86_64.config.system.build.toplevel
+  build-nixos-arm:
+    name: Build NixOS (aarch64-linux)
+    runs-on: ubuntu-24.04-arm
+    timeout-minutes: 60
+    steps:
+      - uses: actions/checkout@v6
+      - uses: cachix/install-nix-action@v31
+      - uses: cachix/cachix-action@v17
+        with:
+          name: jylhis
+          authToken: '${{ secrets.CACHIX_AUTH_TOKEN }}'
+      - run: nix build --accept-flake-config .#nixosConfigurations.aarch64.config.system.build.toplevel
+  build-darwin:
+    name: Build Darwin (aarch64-darwin)
+    runs-on: macos-15-intel
+    timeout-minutes: 60
+    steps:
+      - uses: actions/checkout@v6
+      - uses: cachix/install-nix-action@v31
+      - uses: cachix/cachix-action@v17
+        with:
+          name: jylhis
+          authToken: '${{ secrets.CACHIX_AUTH_TOKEN }}'
+      - run: nix build --accept-flake-config .#darwinConfigurations.aarch64.config.system.build.toplevel

--- a/.github/workflows/validate.yml
+++ b/.github/workflows/validate.yml
@@ -37,17 +37,11 @@ jobs:
           done
           [ "$fail" = 0 ] || exit 1
           echo "All shared inputs pinned in sync."
+  # Fast PR gate: x86_64-linux eval-only checks. Runs on every PR and main push.
   check:
-    name: Check (${{ matrix.system }})
+    name: Check (x86_64-linux)
+    runs-on: ubuntu-latest
     timeout-minutes: 30
-    strategy:
-      fail-fast: false
-      matrix:
-        include:
-          - {system: x86_64-linux, runner: ubuntu-latest}
-          - {system: aarch64-linux, runner: ubuntu-24.04-arm}
-          - {system: aarch64-darwin, runner: macos-15-intel}
-    runs-on: ${{ matrix.runner }}
     steps:
       - uses: actions/checkout@v6
       - uses: cachix/install-nix-action@v31
@@ -56,8 +50,25 @@ jobs:
           name: jylhis
           authToken: '${{ secrets.CACHIX_AUTH_TOKEN }}'
       - run: nix flake check --accept-flake-config
+  # aarch64-linux eval coverage. Main-only — rarely diverges from x86_64 and
+  # would otherwise waste a runner on every PR push.
+  check-arm:
+    name: Check (aarch64-linux)
+    if: github.event_name != 'pull_request'
+    runs-on: ubuntu-24.04-arm
+    timeout-minutes: 30
+    steps:
+      - uses: actions/checkout@v6
+      - uses: cachix/install-nix-action@v31
+      - uses: cachix/cachix-action@v17
+        with:
+          name: jylhis
+          authToken: '${{ secrets.CACHIX_AUTH_TOKEN }}'
+      - run: nix flake check --accept-flake-config
+  # Full NixOS toplevel build. Main-only — up to 60 minutes per run.
   build:
     name: Build toplevel
+    if: github.event_name != 'pull_request'
     runs-on: ubuntu-latest
     needs: [lint, check]
     timeout-minutes: 60


### PR DESCRIPTION
## Summary

Reshape the CI matrix to stop spending macOS minutes on every PR push and to defer the expensive NixOS toplevel build to post-merge.

### What runs where

| Job | PR | `main` push | Release tag (`v*`) / dispatch |
|---|---|---|---|
| `lint` (fmt + lock-file sync) | yes | yes | — |
| `check (x86_64-linux)` (eval-only) | yes | yes | — |
| `check (aarch64-linux)` (eval-only) | **no** | yes | — |
| `build` (NixOS x86_64 toplevel) | **no** | yes | — |
| `build-nixos-x86` / `build-nixos-arm` / `build-darwin` | — | — | yes (parallel, all push to cachix) |

### Changes

- `.github/workflows/validate.yml`
  - Removed `aarch64-darwin` from the check matrix.
  - Split the matrix into separate `check` (x86_64-linux, always) and `check-arm` (aarch64-linux, main only).
  - Gated `check-arm` and `build` on `github.event_name != 'pull_request'`.
- `.github/workflows/release.yml` (new)
  - Triggered by `v*` tags and `workflow_dispatch`.
  - Builds `nixosConfigurations.{x86_64,aarch64}` + `darwinConfigurations.aarch64` toplevels in parallel.
  - All jobs push to the `jylhis` Cachix cache.

### Required follow-up

Update branch protection to require only **`lint`** and **`check (x86_64-linux)`**. The previous required checks (`check (aarch64-linux)`, `check (aarch64-darwin)`, `build`) no longer run on PRs and would otherwise block every PR.

## Test plan

- [ ] Open this PR — confirm only `lint` and `check (x86_64-linux)` jobs appear in the Checks tab; **no Darwin job, no `build` job, no `check-arm` job**.
- [ ] After merge: confirm the resulting push to `main` runs `lint`, `check`, `check-arm`, and `build`.
- [ ] `gh workflow run release.yml` → confirm all three build jobs queue and complete successfully on their respective runners.
- [ ] Optionally cut a throwaway `v0.0.0-test` tag on a scratch branch to validate the tag trigger, then delete the tag.
- [ ] Update required status checks in repo settings after merge.

https://claude.ai/code/session_01Uep2oaFnWp9r7t3JuBRD1T

---
_Generated by [Claude Code](https://claude.ai/code/session_01Uep2oaFnWp9r7t3JuBRD1T)_