### PR TITLE
feat(shell): modern terminal polish — fzf keybindings, zoxide cd, delta pager

### DIFF
--- a/modules/generic/packages.nix
+++ b/modules/generic/packages.nix
@@ -7,7 +7,17 @@ let
 in
 {
   programs =
-    (if hasProgram "zoxide" then { zoxide.enable = true; } else { })
+    (
+      if hasProgram "zoxide" then
+        {
+          zoxide = {
+            enable = true;
+            options = [ "--cmd cd" ];
+          };
+        }
+      else
+        { }
+    )
     // (if hasProgram "nh" then { nh.enable = true; } else { })
     // (if hasProgram "trippy" then { trippy.enable = true; } else { });
 }

--- a/modules/generic/packages.nix
+++ b/modules/generic/packages.nix
@@ -1,4 +1,5 @@
 {
+  lib,
   options,
   ...
 }:
@@ -7,25 +8,14 @@ let
 in
 {
   programs =
-    (
-      if hasProgram "zoxide" then
-        {
-          zoxide =
-            {
-              enable = true;
-            }
-            // (
-              if options.programs.zoxide ? options then
-                {
-                  options = [ "--cmd cd" ];
-                }
-              else
-                { }
-            );
-        }
-      else
-        { }
-    )
-    // (if hasProgram "nh" then { nh.enable = true; } else { })
-    // (if hasProgram "trippy" then { trippy.enable = true; } else { });
+    lib.optionalAttrs (hasProgram "zoxide") {
+      zoxide = {
+        enable = true;
+      }
+      // lib.optionalAttrs (options.programs.zoxide ? options) {
+        options = [ "--cmd cd" ];
+      };
+    }
+    // lib.optionalAttrs (hasProgram "nh") { nh.enable = true; }
+    // lib.optionalAttrs (hasProgram "trippy") { trippy.enable = true; };
 }

--- a/modules/generic/packages.nix
+++ b/modules/generic/packages.nix
@@ -10,10 +10,18 @@ in
     (
       if hasProgram "zoxide" then
         {
-          zoxide = {
-            enable = true;
-            options = [ "--cmd cd" ];
-          };
+          zoxide =
+            {
+              enable = true;
+            }
+            // (
+              if options.programs.zoxide ? options then
+                {
+                  options = [ "--cmd cd" ];
+                }
+              else
+                { }
+            );
         }
       else
         { }

--- a/modules/home/fzf.nix
+++ b/modules/home/fzf.nix
@@ -6,24 +6,23 @@
       enableBashIntegration = lib.mkDefault true;
       enableZshIntegration = lib.mkDefault true;
 
-      defaultCommand = "fd --type f --hidden --follow --exclude .git";
-      defaultOptions = [
+      defaultCommand = lib.mkDefault "fd --type f --hidden --follow --exclude .git";
+      defaultOptions = lib.mkDefault [
         "--height=40%"
         "--layout=reverse"
         "--border"
       ];
 
-      fileWidgetCommand = "fd --type f --hidden --follow --exclude .git";
-      fileWidgetOptions = [
+      fileWidgetOptions = lib.mkDefault [
         "--preview 'bat --style=numbers --color=always --line-range :500 {}'"
       ];
 
-      changeDirWidgetCommand = "fd --type d --hidden --follow --exclude .git";
-      changeDirWidgetOptions = [
+      changeDirWidgetCommand = lib.mkDefault "fd --type d --hidden --follow --exclude .git";
+      changeDirWidgetOptions = lib.mkDefault [
         "--preview 'eza --tree --level=2 --icons --color=always {}'"
       ];
 
-      historyWidgetOptions = [
+      historyWidgetOptions = lib.mkDefault [
         "--sort"
         "--exact"
       ];

--- a/modules/home/fzf.nix
+++ b/modules/home/fzf.nix
@@ -1,7 +1,32 @@
-_: {
+{ lib, ... }:
+{
   config = {
     programs.fzf = {
       enable = true;
+      enableBashIntegration = lib.mkDefault true;
+      enableZshIntegration = lib.mkDefault true;
+
+      defaultCommand = "fd --type f --hidden --follow --exclude .git";
+      defaultOptions = [
+        "--height=40%"
+        "--layout=reverse"
+        "--border"
+      ];
+
+      fileWidgetCommand = "fd --type f --hidden --follow --exclude .git";
+      fileWidgetOptions = [
+        "--preview 'bat --style=numbers --color=always --line-range :500 {}'"
+      ];
+
+      changeDirWidgetCommand = "fd --type d --hidden --follow --exclude .git";
+      changeDirWidgetOptions = [
+        "--preview 'eza --tree --level=2 --icons --color=always {}'"
+      ];
+
+      historyWidgetOptions = [
+        "--sort"
+        "--exact"
+      ];
     };
   };
 }

--- a/modules/home/git.nix
+++ b/modules/home/git.nix
@@ -11,6 +11,19 @@ in
   programs = lib.mkIf userConfig.enable {
     git = {
       enable = true;
+      delta = {
+        enable = true;
+        options = {
+          navigate = true;
+          line-numbers = true;
+          side-by-side = lib.mkDefault false;
+          syntax-theme =
+            if ((osConfig.marchyo or { }).theme.variant or "dark") == "dark" then
+              "jylhis-roast"
+            else
+              "jylhis-paper";
+        };
+      };
       settings = {
         user = {
           name = userConfig.fullname;

--- a/modules/home/git.nix
+++ b/modules/home/git.nix
@@ -12,7 +12,7 @@ in
     git = {
       enable = true;
       delta = {
-        enable = true;
+        enable = lib.mkDefault true;
         options = {
           navigate = true;
           line-numbers = true;


### PR DESCRIPTION
## Summary

Three small but high-impact upgrades inspired by [Julia Evans' "Getting a modern terminal setup"](https://jvns.ca/blog/2025/01/11/getting-a-modern-terminal-setup/). Marchyo already covers nearly everything the post recommends (Ghostty + 24-bit colour, zsh/bash with rich history, eza/bat/rg/fd/fzf, Starship via jylhis-design, Atuin). These three fill the remaining gaps without adding a feature flag or a new module.

- **fzf shell keybindings** (`modules/home/fzf.nix`): `programs.fzf` was a bare `enable = true`. Now Ctrl-T uses fd with a bat preview, Alt-C uses fd directories with an eza tree preview, and `historyWidgetOptions` adds sort + exact match for Ctrl-R when Atuin isn't active. Integration toggles are `lib.mkDefault` so per-shell opt-out still works.
- **zoxide as `cd`** (`modules/generic/packages.nix`): zoxide was already auto-enabled but kept its default `z` / `zi` commands. `--cmd cd` makes the smart-jump behaviour the default `cd`.
- **delta git pager** (`modules/home/git.nix`): `programs.git.delta` enabled with `navigate`, `line-numbers`, and `syntax-theme` picked from `osConfig.marchyo.theme.variant` — reuses the `jylhis-roast` / `jylhis-paper` themes already registered by `modules/home/bat.nix`. Existing `merge.conflictStyle = "zdiff3"` kept (better human merge UX) even though delta prefers `diff3`.

No new options, no new module files, no imports to wire. Everything lives inside already-imported modules.

## Test plan

- [ ] CI: `nix fmt -- --ci` (lint stage) passes
- [ ] CI: `nix flake check --accept-flake-config` evaluates across the matrix — existing `eval-minimal`, `eval-desktop`, `eval-themes-paper`, `eval-all-features` tests exercise the new code paths
- [ ] CI: `nix build .#nixosConfigurations.x86_64.config.system.build.toplevel` succeeds
- [ ] Manual after switch:
  - [ ] New shell, Ctrl-T → fd-backed picker with bat preview
  - [ ] Alt-C → directory picker with eza tree preview
  - [ ] Ctrl-R → Atuin if tracking.shell is on; otherwise fzf history with sort+exact
  - [ ] `cd ~/some-project` jumps from any directory via zoxide
  - [ ] `git diff` in any repo shows delta with line numbers and theme-matched syntax highlighting

https://claude.ai/code/session_01J2LyP9eM2vNubJDoq7R8kg

---
_Generated by [Claude Code](https://claude.ai/code/session_01J2LyP9eM2vNubJDoq7R8kg)_