### PR TITLE
fix: gate jylhis-design overlay on Linux; silence empty-vendors warning when desktop is off

### DIFF
--- a/modules/home/jylhis-theme.nix
+++ b/modules/home/jylhis-theme.nix
@@ -23,38 +23,38 @@ let
   makoConfig = if variant == "roast" then "config" else "config-paper";
 in
 {
-  imports = lib.optionals pkgs.stdenv.isLinux [
-    inputs.jylhis-design.homeManagerModules.default
-  ];
+  imports = [ inputs.jylhis-design.homeManagerModules.default ];
 
-  config = lib.mkIf pkgs.stdenv.isLinux (lib.mkMerge [
-    {
-      jylhis.theme = {
-        inherit (cfg) enable;
-        inherit variant;
-        waybar.enable = false;
-        bat.enable = false;
-        mako.enable = false;
-        gtk.enable = false;
-        # marchyo writes ghostty themes from mkPalette directly so the paper
-        # ANSI 7/15 readability override (see jylhis-palette.nix) is honored.
-        ghostty.enable = false;
-        starship.enable = false;
-      };
-    }
+  config = lib.mkIf pkgs.stdenv.isLinux (
+    lib.mkMerge [
+      {
+        jylhis.theme = {
+          inherit (cfg) enable;
+          inherit variant;
+          waybar.enable = false;
+          bat.enable = false;
+          mako.enable = false;
+          gtk.enable = false;
+          # marchyo writes ghostty themes from mkPalette directly so the paper
+          # ANSI 7/15 readability override (see jylhis-palette.nix) is honored.
+          ghostty.enable = false;
+          starship.enable = false;
+        };
+      }
 
-    (lib.mkIf cfg.enable {
-      xdg.configFile = {
-        "mako/config".source = "${pkgs.jylhis-design-src}/platforms/mako/${makoConfig}";
-        "starship.toml".source = "${pkgs.jylhis-design-src}/platforms/shell/starship.toml";
-      };
+      (lib.mkIf cfg.enable {
+        xdg.configFile = {
+          "mako/config".source = "${pkgs.jylhis-design-src}/platforms/mako/${makoConfig}";
+          "starship.toml".source = "${pkgs.jylhis-design-src}/platforms/shell/starship.toml";
+        };
 
-      gtk = {
-        gtk3.extraCss = builtins.readFile "${pkgs.jylhis-design-src}/platforms/gtk/gtk.css";
-        gtk4.extraCss = builtins.readFile "${pkgs.jylhis-design-src}/platforms/gtk/gtk.css";
-      };
+        gtk = {
+          gtk3.extraCss = builtins.readFile "${pkgs.jylhis-design-src}/platforms/gtk/gtk.css";
+          gtk4.extraCss = builtins.readFile "${pkgs.jylhis-design-src}/platforms/gtk/gtk.css";
+        };
 
-      programs.starship.enable = lib.mkDefault true;
-    })
-  ]);
+        programs.starship.enable = lib.mkDefault true;
+      })
+    ]
+  );
 }

--- a/modules/home/jylhis-theme.nix
+++ b/modules/home/jylhis-theme.nix
@@ -23,9 +23,11 @@ let
   makoConfig = if variant == "roast" then "config" else "config-paper";
 in
 {
-  imports = [ inputs.jylhis-design.homeManagerModules.default ];
+  imports = lib.optionals pkgs.stdenv.isLinux [
+    inputs.jylhis-design.homeManagerModules.default
+  ];
 
-  config = lib.mkMerge [
+  config = lib.mkIf pkgs.stdenv.isLinux (lib.mkMerge [
     {
       jylhis.theme = {
         inherit (cfg) enable;
@@ -54,5 +56,5 @@ in
 
       programs.starship.enable = lib.mkDefault true;
     })
-  ];
+  ]);
 }

--- a/modules/nixos/graphics.nix
+++ b/modules/nixos/graphics.nix
@@ -135,7 +135,7 @@ in
 
     # Assertions and warnings
     {
-      warnings = lib.optionals (cfg.vendors == [ ] && isX86) [
+      warnings = lib.optionals (cfg.vendors == [ ] && isX86 && config.marchyo.desktop.enable) [
         "marchyo.graphics.vendors is empty on x86_64. This defaults to Intel behavior. Set vendors explicitly (e.g. [\"nvidia\"] or [\"amd\"])."
       ];
 

--- a/modules/nixos/graphics.nix
+++ b/modules/nixos/graphics.nix
@@ -135,7 +135,7 @@ in
 
     # Assertions and warnings
     {
-      warnings = lib.optionals (cfg.vendors == [ ] && isX86 && config.marchyo.desktop.enable) [
+      warnings = lib.optionals (legacyIntel && config.marchyo.desktop.enable) [
         "marchyo.graphics.vendors is empty on x86_64. This defaults to Intel behavior. Set vendors explicitly (e.g. [\"nvidia\"] or [\"amd\"])."
       ];
 

--- a/overlay.nix
+++ b/overlay.nix
@@ -1,13 +1,15 @@
 { inputs }:
 final: prev:
-(inputs.jylhis-design.overlays.default final prev)
-// {
+{
   jylhis-design-src = inputs.jylhis-design;
 }
-// prev.lib.optionalAttrs prev.stdenv.isLinux {
-  vicinae = inputs.vicinae.packages.${final.stdenv.hostPlatform.system}.default;
-  noctalia = inputs.noctalia.packages.${final.stdenv.hostPlatform.system}.default;
+// prev.lib.optionalAttrs prev.stdenv.isLinux (
+  (inputs.jylhis-design.overlays.default final prev)
+  // {
+    vicinae = inputs.vicinae.packages.${final.stdenv.hostPlatform.system}.default;
+    noctalia = inputs.noctalia.packages.${final.stdenv.hostPlatform.system}.default;
 
-  hyprmon = final.callPackage ./packages/hyprmon/package.nix { };
-  plymouth-marchyo-theme = final.callPackage ./packages/plymouth-marchyo-theme/package.nix { };
-}
+    hyprmon = final.callPackage ./packages/hyprmon/package.nix { };
+    plymouth-marchyo-theme = final.callPackage ./packages/plymouth-marchyo-theme/package.nix { };
+  }
+)


### PR DESCRIPTION
## Summary

Cross-platform `nix flake check` (Linux evaluator, darwin pkgs set) was bombing with a `Required system: 'x86_64-darwin'` IFD failure on `jylhis-themes-0.3.0` whenever a downstream consumer mapped marchyo's `homeManagerModules.default` onto a darwin home-manager user (e.g. the markus profile's `modules/k9s/hm.nix` reads files from `pkgs.jylhis-themes` and forces a build of the darwin derivation while the evaluator is on Linux).

Root cause: `overlay.nix` merged `inputs.jylhis-design.overlays.default` unconditionally, leaking `pkgs.jylhis-themes` into the darwin pkgs set; `modules/home/jylhis-theme.nix` imported the upstream HM module unconditionally even though its config body is Linux-only.

- **`overlay.nix`** — fold the `jylhis-design.overlays.default` merge inside the existing `lib.optionalAttrs prev.stdenv.isLinux` block. `jylhis-design-src` stays cross-platform (it's just a flake input source path used for `builtins.readFile` reads).
- **`modules/home/jylhis-theme.nix`** — gate both `imports` and `config` on `pkgs.stdenv.isLinux`. The mako/gtk/starship assets are Linux-only, and the upstream module needs `pkgs.jylhis-themes` which is now Linux-only.
- **`modules/nixos/graphics.nix`** — only emit the `vendors is empty on x86_64` warning when `marchyo.desktop.enable = true`. Server/headless x86_64 configs no longer need to opt out of a graphics warning that doesn't apply to them.

The reference `nixosConfigurations.x86_64` already sets both `desktop.enable = true` and `vendors = [ "intel" ]`, so it stays warning-free. Marchyo's own `darwinConfigurations` don't wire the home modules, so this PR doesn't change anything visible on the darwin CI runner — it unblocks consumers who do.

## Out of scope

- The downstream `programs.claude-code.memory.source → programs.claude-code.context` rename warning lives in the markus profile, not marchyo (`modules/home/claude-code.nix` only writes a `SKILL.md`).
- The downstream `nixpkgs.config`/`nixpkgs.overlays` under `useGlobalPkgs` warning — no marchyo home module sets these.

## Test plan

- [ ] `just fmt` is clean (CI lint job)
- [ ] `just check` passes — exercises `eval-minimal`, `eval-desktop`, `eval-themes-paper`, `eval-graphics-legacy`
- [ ] `nix eval .#darwinConfigurations.{aarch64,x86_64}.config.system.build.toplevel.outPath` from a Linux host completes without the `Required system: 'x86_64-darwin'` error
- [ ] `nix eval --json .#nixosConfigurations.x86_64.config.warnings` no longer contains the `vendors is empty` entry (it shouldn't have, since vendors is set — confirms the warning path didn't regress)
- [ ] Locally flip `marchyo.desktop.enable = false` with empty vendors — warning is gone; flip back to `desktop.enable = true` with empty vendors — warning fires again
- [ ] Re-run `nix flake check` in the downstream markus profile: the IFD error and the `vendors is empty` warning are absent

https://claude.ai/code/session_013SVc6BhryoiVWVdG9wzFJ9

---
_Generated by [Claude Code](https://claude.ai/code/session_013SVc6BhryoiVWVdG9wzFJ9)_