### PR TITLE
feat: Hyprland ↔ Emacs integration module

### DIFF
--- a/modules/home/emacs.nix
+++ b/modules/home/emacs.nix
@@ -7,6 +7,7 @@
 let
   cfg = (osConfig.marchyo or { }).emacs or { };
   enabled = cfg.enable or false;
+  emacsPkg = cfg.package or pkgs.emacs-pgtk;
 
   windmoveEnabled = enabled && (cfg.windmove.enable or true);
   eventListenerEnabled = enabled && (cfg.eventListener.enable or true);
@@ -14,68 +15,17 @@ let
   everywhereEnabled = enabled && (cfg.everywhere.enable or true);
   orgProtocolEnabled = enabled && (cfg.orgProtocol.enable or true);
 
-  windmoveScript = pkgs.writeShellApplication {
-    name = "marchyo-cross-windmove";
-    runtimeInputs = with pkgs; [
-      jq
-      hyprland
-      procps
-    ];
-    text = ''
-      mode="''${1:-focus}"
-      dir="''${2:-}"
-      case "$dir" in l|r|u|d) ;; *) echo "usage: $0 <focus|move> <l|r|u|d>" >&2; exit 2 ;; esac
-
-      case "$dir" in
-        l) elisp_dir=left ;;
-        r) elisp_dir=right ;;
-        u) elisp_dir=up ;;
-        d) elisp_dir=down ;;
-      esac
-
-      class="$(hyprctl activewindow -j | jq -r '.class // ""')"
-
-      if [ "$class" = "Emacs" ] && pgrep -u "$USER" -x emacs >/dev/null 2>&1; then
-        case "$mode" in
-          focus) emacsclient -e "(marchyo/windmove-or-hypr '$elisp_dir)" >/dev/null 2>&1 \
-                   || hyprctl dispatch movefocus "$dir" ;;
-          move)  emacsclient -e "(marchyo/move-window-or-hypr '$elisp_dir)" >/dev/null 2>&1 \
-                   || hyprctl dispatch swapwindow "$dir" ;;
-        esac
-      else
-        case "$mode" in
-          focus) hyprctl dispatch movefocus "$dir" ;;
-          move)  hyprctl dispatch swapwindow "$dir" ;;
-        esac
-      fi
-    '';
-  };
-
-  scratchpadScript = pkgs.writeShellApplication {
-    name = "marchyo-emacs-scratchpad";
-    runtimeInputs = with pkgs; [
-      hyprland
-      jq
-    ];
-    text = ''
-      # Spawn the named frame if it isn't already alive, then toggle the
-      # `magic` special workspace it lives on.
-      if ! hyprctl clients -j | jq -e '.[] | select(.title == "emacs-scratchpad")' >/dev/null; then
-        emacsclient -c -n -F '((name . "emacs-scratchpad"))' -e '(scratch-buffer)' \
-          >/dev/null 2>&1 || true
-      fi
-      hyprctl dispatch togglespecialworkspace magic
-    '';
-  };
+  needsElispPkg = windmoveEnabled || eventListenerEnabled;
 
   windmoveEl = ''
     ;;; marchyo-windmove.el --- Cross-WM windmove for Hyprland -*- lexical-binding: t -*-
     (require 'windmove)
 
-    (defun marchyo/hyprctl (&rest args)
+    (defun marchyo--hyprctl (&rest args)
       "Run hyprctl ARGS; return t on success."
       (eq 0 (apply #'call-process "hyprctl" nil nil nil args)))
 
+    ;;;###autoload
     (defun marchyo/windmove-or-hypr (dir)
       "Try `windmove-DIR' first; on edge, hand focus to Hyprland.
     DIR is one of `left', `right', `up', `down'."
@@ -83,15 +33,16 @@ let
             (hypr (pcase dir ('left "l") ('right "r") ('up "u") ('down "d"))))
         (condition-case _
             (funcall fn)
-          (user-error (marchyo/hyprctl "dispatch" "movefocus" hypr)))))
+          (user-error (marchyo--hyprctl "dispatch" "movefocus" hypr)))))
 
+    ;;;###autoload
     (defun marchyo/move-window-or-hypr (dir)
       "Like `marchyo/windmove-or-hypr' but swap windows."
       (let ((fn (intern (format "windmove-swap-states-%s" dir)))
             (hypr (pcase dir ('left "l") ('right "r") ('up "u") ('down "d"))))
         (condition-case _
             (funcall fn)
-          (user-error (marchyo/hyprctl "dispatch" "swapwindow" hypr)))))
+          (user-error (marchyo--hyprctl "dispatch" "swapwindow" hypr)))))
 
     (provide 'marchyo-windmove)
     ;;; marchyo-windmove.el ends here
@@ -110,12 +61,19 @@ let
         (when (and sig run)
           (format "%s/hypr/%s/.socket2.sock" run sig))))
 
-    (defun marchyo-hypr--filter (_proc string)
-      (dolist (line (split-string string "\n" t))
-        (when (string-match "\\`\\([^>]+\\)>>\\(.*\\)\\'" line)
-          (run-hook-with-args 'marchyo-hypr-event-hook
-                              (cons (match-string 1 line)
-                                    (match-string 2 line))))))
+    (defun marchyo-hypr--filter (proc string)
+      "Buffer PROC output until newline-terminated lines arrive, then dispatch."
+      (let* ((pending (or (process-get proc 'marchyo-pending) ""))
+             (full (concat pending string))
+             (parts (split-string full "\n"))
+             (last (car (last parts)))
+             (lines (butlast parts)))
+        (process-put proc 'marchyo-pending last)
+        (dolist (line lines)
+          (when (string-match "\\`\\([^>]+\\)>>\\(.*\\)\\'" line)
+            (run-hook-with-args 'marchyo-hypr-event-hook
+                                (cons (match-string 1 line)
+                                      (match-string 2 line)))))))
 
     ;;;###autoload
     (defun marchyo-hypr-event-start ()
@@ -130,10 +88,11 @@ let
               (make-network-process
                :name "marchyo-hypr-events"
                :family 'local
-               :remote path
+               :service path
                :filter #'marchyo-hypr--filter
                :noquery t))))
 
+    ;;;###autoload
     (defun marchyo-hypr-event-stop ()
       "Disconnect from the Hyprland event socket."
       (interactive)
@@ -163,7 +122,9 @@ let
       (add-hook 'marchyo-hypr-event-hook #'marchyo-persp--on-event)
       (marchyo-hypr-event-start))
 
+    ;;;###autoload
     (defun marchyo-persp-disable ()
+      "Stop mirroring Hyprland workspaces onto perspective.el."
       (interactive)
       (remove-hook 'marchyo-hypr-event-hook #'marchyo-persp--on-event))
 
@@ -171,31 +132,101 @@ let
     ;;; marchyo-persp.el ends here
   '';
 
-  initSnippetEl = ''
-    ;;; marchyo-init.el --- Bootstrap for Marchyo's Hyprland integration -*- lexical-binding: t -*-
-    ;; Add this file's directory to load-path, then `(require 'marchyo-init)`
-    ;; from your own init.el (or `(load "~/.config/marchyo/emacs/marchyo-init.el")`).
-    ;;
-    ;; Loading marchyo-init pulls in the helpers Marchyo has enabled. Wire
-    ;; up perspective and event listeners explicitly so you stay in control:
-    ;;
-    ;;   (when (featurep 'marchyo-persp) (marchyo-persp-enable))
-
-    (add-to-list 'load-path (file-name-directory (or load-file-name buffer-file-name)))
-    ${lib.optionalString windmoveEnabled "(require 'marchyo-windmove)"}
-    ${lib.optionalString eventListenerEnabled "(require 'marchyo-hypr-events)"}
-    ${lib.optionalString eventListenerEnabled "(require 'marchyo-persp)"}
-
-    (provide 'marchyo-init)
-    ;;; marchyo-init.el ends here
+  elispSrc = pkgs.runCommand "marchyo-hypr-elisp-src" { } ''
+    mkdir -p $out
+    ${lib.optionalString windmoveEnabled ''
+      install -m644 ${pkgs.writeText "marchyo-windmove.el" windmoveEl} $out/marchyo-windmove.el
+    ''}
+    ${lib.optionalString eventListenerEnabled ''
+      install -m644 ${pkgs.writeText "marchyo-hypr-events.el" hyprEventsEl} $out/marchyo-hypr-events.el
+      install -m644 ${pkgs.writeText "marchyo-persp.el" perspEl} $out/marchyo-persp.el
+    ''}
   '';
 
+  windmoveScript = pkgs.writeShellApplication {
+    name = "marchyo-cross-windmove";
+    runtimeInputs = [
+      pkgs.jq
+      pkgs.hyprland
+      pkgs.procps
+      emacsPkg
+    ];
+    text = ''
+      mode="''${1:-focus}"
+      dir="''${2:-}"
+      case "$dir" in l|r|u|d) ;; *) echo "usage: $0 <focus|move> <l|r|u|d>" >&2; exit 2 ;; esac
+
+      case "$dir" in
+        l) elisp_dir=left ;;
+        r) elisp_dir=right ;;
+        u) elisp_dir=up ;;
+        d) elisp_dir=down ;;
+      esac
+
+      class="$(hyprctl activewindow -j | jq -r '.class // ""')"
+
+      case "$class" in
+        Emacs|emacs)
+          if pgrep -u "$USER" -x emacs >/dev/null 2>&1; then
+            case "$mode" in
+              focus)
+                emacsclient -e "(marchyo/windmove-or-hypr '$elisp_dir)" >/dev/null 2>&1 \
+                  || hyprctl dispatch movefocus "$dir"
+                ;;
+              move)
+                emacsclient -e "(marchyo/move-window-or-hypr '$elisp_dir)" >/dev/null 2>&1 \
+                  || hyprctl dispatch swapwindow "$dir"
+                ;;
+            esac
+          else
+            case "$mode" in
+              focus) hyprctl dispatch movefocus "$dir" ;;
+              move)  hyprctl dispatch swapwindow "$dir" ;;
+            esac
+          fi
+          ;;
+        *)
+          case "$mode" in
+            focus) hyprctl dispatch movefocus "$dir" ;;
+            move)  hyprctl dispatch swapwindow "$dir" ;;
+          esac
+          ;;
+      esac
+    '';
+  };
+
+  scratchpadScript = pkgs.writeShellApplication {
+    name = "marchyo-emacs-scratchpad";
+    runtimeInputs = [
+      pkgs.hyprland
+      emacsPkg
+    ];
+    text = ''
+      # Ask the Emacs daemon whether the named frame already exists, and only
+      # spawn one if not. Querying the frame list directly is more reliable
+      # than parsing `hyprctl clients` because the user can change the
+      # scratchpad buffer (and therefore the window title) without Emacs
+      # renaming the frame.
+      have_frame=$(emacsclient -e \
+        "(if (member \"emacs-scratchpad\" (mapcar (lambda (f) (frame-parameter f 'name)) (frame-list))) t nil)" \
+        2>/dev/null || echo nil)
+      if [ "$have_frame" != "t" ]; then
+        emacsclient -c -n \
+          -F '((name . "emacs-scratchpad") (title . "emacs-scratchpad"))' \
+          -e '(scratch-buffer)' >/dev/null 2>&1 || true
+      fi
+      hyprctl dispatch togglespecialworkspace magic
+    '';
+  };
+
+  # pgtk reports the Wayland app-id as lowercase `emacs`; X11/native uses
+  # uppercase `Emacs`. Match both so the rules apply regardless of build.
   hyprWindowRules = lib.optionals enabled [
-    "float on, match:class ^(Emacs)$, match:title ^(emacs-scratchpad)$"
-    "workspace special:magic silent, match:class ^(Emacs)$, match:title ^(emacs-scratchpad)$"
-    "float on, match:class ^(Emacs)$, match:title ^(emacs-everywhere)$"
-    "size 800 500, match:class ^(Emacs)$, match:title ^(emacs-everywhere)$"
-    "center on, match:class ^(Emacs)$, match:title ^(emacs-everywhere)$"
+    "float on, match:class ^(Emacs|emacs)$, match:title ^(emacs-scratchpad)$"
+    "workspace special:magic silent, match:class ^(Emacs|emacs)$, match:title ^(emacs-scratchpad)$"
+    "float on, match:class ^(Emacs|emacs)$, match:title ^(emacs-everywhere)$"
+    "size 800 500, match:class ^(Emacs|emacs)$, match:title ^(emacs-everywhere)$"
+    "center on, match:class ^(Emacs|emacs)$, match:title ^(emacs-everywhere)$"
   ];
 
   hyprBindd =
@@ -226,38 +257,41 @@ in
   config = lib.mkIf enabled {
     programs.emacs = {
       enable = true;
-      package = cfg.package;
+      package = emacsPkg;
+      # Ship the integration as a real Emacs package so the autoload cookies
+      # on `marchyo/windmove-or-hypr` & co. are registered at daemon
+      # startup — no manual `(require)` from the user's init.el needed.
       extraPackages =
         epkgs:
-        (lib.optional everywhereEnabled epkgs.emacs-everywhere)
+        let
+          marchyoElisp = epkgs.trivialBuild {
+            pname = "marchyo-hypr";
+            version = "0.1.0";
+            src = elispSrc;
+          };
+        in
+        (lib.optional needsElispPkg marchyoElisp)
+        ++ (lib.optional everywhereEnabled epkgs.emacs-everywhere)
         ++ (lib.optional eventListenerEnabled epkgs.perspective);
     };
 
     services.emacs = {
       enable = true;
       defaultEditor = lib.mkDefault false;
+      # `services.emacs.client.enable` installs `emacsclient.desktop`, which
+      # both the editor MIME registration (modules/home/xdg.nix) and the
+      # org-protocol URL handler resolve to. Without it those handlers point
+      # at a missing desktop file.
+      client.enable = lib.mkDefault true;
     };
 
     home.packages = lib.mkIf everywhereEnabled (
       with pkgs;
       [
-        # emacs-everywhere shells out to wl-clipboard + wtype on Wayland.
         wl-clipboard
         wtype
       ]
     );
-
-    xdg.configFile =
-      {
-        "marchyo/emacs/marchyo-init.el".text = initSnippetEl;
-      }
-      // lib.optionalAttrs windmoveEnabled {
-        "marchyo/emacs/marchyo-windmove.el".text = windmoveEl;
-      }
-      // lib.optionalAttrs eventListenerEnabled {
-        "marchyo/emacs/marchyo-hypr-events.el".text = hyprEventsEl;
-        "marchyo/emacs/marchyo-persp.el".text = perspEl;
-      };
 
     wayland.windowManager.hyprland.settings = {
       windowrule = lib.mkAfter hyprWindowRules;

--- a/modules/home/emacs.nix
+++ b/modules/home/emacs.nix
@@ -1,0 +1,267 @@
+{
+  lib,
+  pkgs,
+  osConfig ? { },
+  ...
+}:
+let
+  cfg = (osConfig.marchyo or { }).emacs or { };
+  enabled = cfg.enable or false;
+
+  windmoveEnabled = enabled && (cfg.windmove.enable or true);
+  eventListenerEnabled = enabled && (cfg.eventListener.enable or true);
+  scratchpadEnabled = enabled && (cfg.scratchpad.enable or true);
+  everywhereEnabled = enabled && (cfg.everywhere.enable or true);
+  orgProtocolEnabled = enabled && (cfg.orgProtocol.enable or true);
+
+  windmoveScript = pkgs.writeShellApplication {
+    name = "marchyo-cross-windmove";
+    runtimeInputs = with pkgs; [
+      jq
+      hyprland
+      procps
+    ];
+    text = ''
+      mode="''${1:-focus}"
+      dir="''${2:-}"
+      case "$dir" in l|r|u|d) ;; *) echo "usage: $0 <focus|move> <l|r|u|d>" >&2; exit 2 ;; esac
+
+      case "$dir" in
+        l) elisp_dir=left ;;
+        r) elisp_dir=right ;;
+        u) elisp_dir=up ;;
+        d) elisp_dir=down ;;
+      esac
+
+      class="$(hyprctl activewindow -j | jq -r '.class // ""')"
+
+      if [ "$class" = "Emacs" ] && pgrep -u "$USER" -x emacs >/dev/null 2>&1; then
+        case "$mode" in
+          focus) emacsclient -e "(marchyo/windmove-or-hypr '$elisp_dir)" >/dev/null 2>&1 \
+                   || hyprctl dispatch movefocus "$dir" ;;
+          move)  emacsclient -e "(marchyo/move-window-or-hypr '$elisp_dir)" >/dev/null 2>&1 \
+                   || hyprctl dispatch swapwindow "$dir" ;;
+        esac
+      else
+        case "$mode" in
+          focus) hyprctl dispatch movefocus "$dir" ;;
+          move)  hyprctl dispatch swapwindow "$dir" ;;
+        esac
+      fi
+    '';
+  };
+
+  scratchpadScript = pkgs.writeShellApplication {
+    name = "marchyo-emacs-scratchpad";
+    runtimeInputs = with pkgs; [
+      hyprland
+      jq
+    ];
+    text = ''
+      # Spawn the named frame if it isn't already alive, then toggle the
+      # `magic` special workspace it lives on.
+      if ! hyprctl clients -j | jq -e '.[] | select(.title == "emacs-scratchpad")' >/dev/null; then
+        emacsclient -c -n -F '((name . "emacs-scratchpad"))' -e '(scratch-buffer)' \
+          >/dev/null 2>&1 || true
+      fi
+      hyprctl dispatch togglespecialworkspace magic
+    '';
+  };
+
+  windmoveEl = ''
+    ;;; marchyo-windmove.el --- Cross-WM windmove for Hyprland -*- lexical-binding: t -*-
+    (require 'windmove)
+
+    (defun marchyo/hyprctl (&rest args)
+      "Run hyprctl ARGS; return t on success."
+      (eq 0 (apply #'call-process "hyprctl" nil nil nil args)))
+
+    (defun marchyo/windmove-or-hypr (dir)
+      "Try `windmove-DIR' first; on edge, hand focus to Hyprland.
+    DIR is one of `left', `right', `up', `down'."
+      (let ((fn (intern (format "windmove-%s" dir)))
+            (hypr (pcase dir ('left "l") ('right "r") ('up "u") ('down "d"))))
+        (condition-case _
+            (funcall fn)
+          (user-error (marchyo/hyprctl "dispatch" "movefocus" hypr)))))
+
+    (defun marchyo/move-window-or-hypr (dir)
+      "Like `marchyo/windmove-or-hypr' but swap windows."
+      (let ((fn (intern (format "windmove-swap-states-%s" dir)))
+            (hypr (pcase dir ('left "l") ('right "r") ('up "u") ('down "d"))))
+        (condition-case _
+            (funcall fn)
+          (user-error (marchyo/hyprctl "dispatch" "swapwindow" hypr)))))
+
+    (provide 'marchyo-windmove)
+    ;;; marchyo-windmove.el ends here
+  '';
+
+  hyprEventsEl = ''
+    ;;; marchyo-hypr-events.el --- Subscribe to Hyprland IPC events -*- lexical-binding: t -*-
+    (defvar marchyo-hypr-event-process nil)
+    (defvar marchyo-hypr-event-hook nil
+      "Hook run for every Hyprland event.
+    Each function receives one cons cell (EVENT-NAME . DATA-STRING).")
+
+    (defun marchyo-hypr--socket-path ()
+      (let ((sig (getenv "HYPRLAND_INSTANCE_SIGNATURE"))
+            (run (getenv "XDG_RUNTIME_DIR")))
+        (when (and sig run)
+          (format "%s/hypr/%s/.socket2.sock" run sig))))
+
+    (defun marchyo-hypr--filter (_proc string)
+      (dolist (line (split-string string "\n" t))
+        (when (string-match "\\`\\([^>]+\\)>>\\(.*\\)\\'" line)
+          (run-hook-with-args 'marchyo-hypr-event-hook
+                              (cons (match-string 1 line)
+                                    (match-string 2 line))))))
+
+    ;;;###autoload
+    (defun marchyo-hypr-event-start ()
+      "Connect to the Hyprland event socket."
+      (interactive)
+      (let ((path (marchyo-hypr--socket-path)))
+        (unless path
+          (user-error "Hyprland sockets not available (HYPRLAND_INSTANCE_SIGNATURE unset)"))
+        (when (process-live-p marchyo-hypr-event-process)
+          (delete-process marchyo-hypr-event-process))
+        (setq marchyo-hypr-event-process
+              (make-network-process
+               :name "marchyo-hypr-events"
+               :family 'local
+               :remote path
+               :filter #'marchyo-hypr--filter
+               :noquery t))))
+
+    (defun marchyo-hypr-event-stop ()
+      "Disconnect from the Hyprland event socket."
+      (interactive)
+      (when (process-live-p marchyo-hypr-event-process)
+        (delete-process marchyo-hypr-event-process)
+        (setq marchyo-hypr-event-process nil)))
+
+    (provide 'marchyo-hypr-events)
+    ;;; marchyo-hypr-events.el ends here
+  '';
+
+  perspEl = ''
+    ;;; marchyo-persp.el --- Follow Hyprland workspaces with perspective.el -*- lexical-binding: t -*-
+    (require 'marchyo-hypr-events)
+    (autoload 'persp-switch "perspective" nil t)
+
+    (defun marchyo-persp--on-event (event)
+      (pcase event
+        (`("workspace" . ,name)
+         (when (fboundp 'persp-switch)
+           (persp-switch (format "ws%s" name))))))
+
+    ;;;###autoload
+    (defun marchyo-persp-enable ()
+      "Subscribe to Hyprland events and mirror them onto perspective.el."
+      (interactive)
+      (add-hook 'marchyo-hypr-event-hook #'marchyo-persp--on-event)
+      (marchyo-hypr-event-start))
+
+    (defun marchyo-persp-disable ()
+      (interactive)
+      (remove-hook 'marchyo-hypr-event-hook #'marchyo-persp--on-event))
+
+    (provide 'marchyo-persp)
+    ;;; marchyo-persp.el ends here
+  '';
+
+  initSnippetEl = ''
+    ;;; marchyo-init.el --- Bootstrap for Marchyo's Hyprland integration -*- lexical-binding: t -*-
+    ;; Add this file's directory to load-path, then `(require 'marchyo-init)`
+    ;; from your own init.el (or `(load "~/.config/marchyo/emacs/marchyo-init.el")`).
+    ;;
+    ;; Loading marchyo-init pulls in the helpers Marchyo has enabled. Wire
+    ;; up perspective and event listeners explicitly so you stay in control:
+    ;;
+    ;;   (when (featurep 'marchyo-persp) (marchyo-persp-enable))
+
+    (add-to-list 'load-path (file-name-directory (or load-file-name buffer-file-name)))
+    ${lib.optionalString windmoveEnabled "(require 'marchyo-windmove)"}
+    ${lib.optionalString eventListenerEnabled "(require 'marchyo-hypr-events)"}
+    ${lib.optionalString eventListenerEnabled "(require 'marchyo-persp)"}
+
+    (provide 'marchyo-init)
+    ;;; marchyo-init.el ends here
+  '';
+
+  hyprWindowRules = lib.optionals enabled [
+    "float on, match:class ^(Emacs)$, match:title ^(emacs-scratchpad)$"
+    "workspace special:magic silent, match:class ^(Emacs)$, match:title ^(emacs-scratchpad)$"
+    "float on, match:class ^(Emacs)$, match:title ^(emacs-everywhere)$"
+    "size 800 500, match:class ^(Emacs)$, match:title ^(emacs-everywhere)$"
+    "center on, match:class ^(Emacs)$, match:title ^(emacs-everywhere)$"
+  ];
+
+  hyprBindd =
+    lib.optionals enabled [
+      "SUPER SHIFT, E, New Emacs frame, exec, emacsclient -c -n"
+    ]
+    ++ lib.optionals windmoveEnabled [
+      "SUPER ALT, H, Focus window (Emacs-aware) left,  exec, ${windmoveScript}/bin/marchyo-cross-windmove focus l"
+      "SUPER ALT, L, Focus window (Emacs-aware) right, exec, ${windmoveScript}/bin/marchyo-cross-windmove focus r"
+      "SUPER ALT, K, Focus window (Emacs-aware) up,    exec, ${windmoveScript}/bin/marchyo-cross-windmove focus u"
+      "SUPER ALT, J, Focus window (Emacs-aware) down,  exec, ${windmoveScript}/bin/marchyo-cross-windmove focus d"
+      "SUPER ALT SHIFT, H, Swap window (Emacs-aware) left,  exec, ${windmoveScript}/bin/marchyo-cross-windmove move l"
+      "SUPER ALT SHIFT, L, Swap window (Emacs-aware) right, exec, ${windmoveScript}/bin/marchyo-cross-windmove move r"
+      "SUPER ALT SHIFT, K, Swap window (Emacs-aware) up,    exec, ${windmoveScript}/bin/marchyo-cross-windmove move u"
+      "SUPER ALT SHIFT, J, Swap window (Emacs-aware) down,  exec, ${windmoveScript}/bin/marchyo-cross-windmove move d"
+    ]
+    ++ lib.optionals scratchpadEnabled [
+      "SUPER, Z, Emacs scratchpad, exec, ${scratchpadScript}/bin/marchyo-emacs-scratchpad"
+    ]
+    ++ lib.optionals everywhereEnabled [
+      "SUPER CTRL, E, Emacs everywhere, exec, emacsclient -ne '(emacs-everywhere)'"
+    ]
+    ++ lib.optionals orgProtocolEnabled [
+      "SUPER SHIFT, C, Org capture, exec, emacsclient -c -n -e '(org-capture)'"
+    ];
+in
+{
+  config = lib.mkIf enabled {
+    programs.emacs = {
+      enable = true;
+      package = cfg.package;
+      extraPackages =
+        epkgs:
+        (lib.optional everywhereEnabled epkgs.emacs-everywhere)
+        ++ (lib.optional eventListenerEnabled epkgs.perspective);
+    };
+
+    services.emacs = {
+      enable = true;
+      defaultEditor = lib.mkDefault false;
+    };
+
+    home.packages = lib.mkIf everywhereEnabled (
+      with pkgs;
+      [
+        # emacs-everywhere shells out to wl-clipboard + wtype on Wayland.
+        wl-clipboard
+        wtype
+      ]
+    );
+
+    xdg.configFile =
+      {
+        "marchyo/emacs/marchyo-init.el".text = initSnippetEl;
+      }
+      // lib.optionalAttrs windmoveEnabled {
+        "marchyo/emacs/marchyo-windmove.el".text = windmoveEl;
+      }
+      // lib.optionalAttrs eventListenerEnabled {
+        "marchyo/emacs/marchyo-hypr-events.el".text = hyprEventsEl;
+        "marchyo/emacs/marchyo-persp.el".text = perspEl;
+      };
+
+    wayland.windowManager.hyprland.settings = {
+      windowrule = lib.mkAfter hyprWindowRules;
+      bindd = lib.mkAfter hyprBindd;
+    };
+  };
+}

--- a/modules/home/xdg.nix
+++ b/modules/home/xdg.nix
@@ -114,6 +114,12 @@ let
       { "x-scheme-handler/mailto" = browserDesktop; }
     else
       { };
+
+  emacsCfg = (osConfig.marchyo or { }).emacs or { };
+  orgProtocolEnabled = (emacsCfg.enable or false) && (emacsCfg.orgProtocol.enable or true);
+  orgProtocolMimeTypes = lib.optionalAttrs orgProtocolEnabled {
+    "x-scheme-handler/org-protocol" = [ "emacsclient.desktop" ];
+  };
 in
 {
   config = lib.mkIf desktopEnabled {
@@ -148,7 +154,8 @@ in
       // audioMimeTypes
       // browserMimeTypes
       // editorMimeTypes
-      // emailMimeTypes;
+      // emailMimeTypes
+      // orgProtocolMimeTypes;
     };
   };
 }

--- a/modules/nixos/options/emacs.nix
+++ b/modules/nixos/options/emacs.nix
@@ -1,0 +1,76 @@
+{ lib, pkgs, ... }:
+let
+  inherit (lib) mkEnableOption mkOption types;
+in
+{
+  options.marchyo.emacs = {
+    enable = mkEnableOption "Marchyo Emacs daemon and Hyprland integration";
+
+    package = mkOption {
+      type = types.package;
+      default = pkgs.emacs-pgtk;
+      defaultText = lib.literalExpression "pkgs.emacs-pgtk";
+      description = ''
+        Emacs package to use for the user daemon. Defaults to the
+        Wayland-native pgtk build.
+      '';
+    };
+
+    windmove = {
+      enable = mkOption {
+        type = types.bool;
+        default = true;
+        description = ''
+          Cross-WM directional focus: SUPER+ALT+H/J/K/L tries
+          `windmove-*` inside Emacs first and falls through to
+          `hyprctl dispatch movefocus` when at the frame edge.
+          SUPER+ALT+SHIFT+H/J/K/L does the same for window swap.
+        '';
+      };
+    };
+
+    eventListener = {
+      enable = mkOption {
+        type = types.bool;
+        default = true;
+        description = ''
+          Subscribe to the Hyprland `.socket2.sock` event stream from
+          Emacs and run hooks on workspace/window changes.
+        '';
+      };
+    };
+
+    scratchpad = {
+      enable = mkOption {
+        type = types.bool;
+        default = true;
+        description = ''
+          SUPER+Z toggles an emacsclient frame titled
+          `emacs-scratchpad` onto the `magic` special workspace.
+        '';
+      };
+    };
+
+    everywhere = {
+      enable = mkOption {
+        type = types.bool;
+        default = true;
+        description = ''
+          SUPER+CTRL+E captures the focused text field into a temporary
+          Emacs frame via emacs-everywhere.
+        '';
+      };
+    };
+
+    orgProtocol = {
+      enable = mkOption {
+        type = types.bool;
+        default = true;
+        description = ''
+          Register `x-scheme-handler/org-protocol` and bind
+          SUPER+SHIFT+C to `(org-capture)`.
+        '';
+      };
+    };
+  };
+}

--- a/tests/eval/emacs.nix
+++ b/tests/eval/emacs.nix
@@ -1,0 +1,37 @@
+{
+  helpers,
+  homeManagerModules,
+  ...
+}:
+let
+  inherit (helpers) testNixOS withTestUser;
+
+  withHM =
+    extra:
+    withTestUser (
+      {
+        marchyo.desktop.enable = true;
+        home-manager.users.testuser = {
+          imports = [ homeManagerModules ];
+        };
+      }
+      // extra
+    );
+in
+{
+  eval-emacs-disabled = testNixOS "emacs-disabled" (withHM { });
+
+  eval-emacs-enabled = testNixOS "emacs-enabled" (withHM {
+    marchyo.emacs.enable = true;
+  });
+
+  # Every sub-feature off — module should still evaluate.
+  eval-emacs-minimal = testNixOS "emacs-minimal" (withHM {
+    marchyo.emacs.enable = true;
+    marchyo.emacs.windmove.enable = false;
+    marchyo.emacs.eventListener.enable = false;
+    marchyo.emacs.scratchpad.enable = false;
+    marchyo.emacs.everywhere.enable = false;
+    marchyo.emacs.orgProtocol.enable = false;
+  });
+}


### PR DESCRIPTION
## Summary

Inspired by https://khz.ac/software/i3-integration.html — i3's `--passthrough` patch unified key handling across the WM and Emacs. Hyprland needs no patching: `hyprctl` + `.socket2.sock` already provide everything the i3 patch did, with comparable latency.

Adds a new `marchyo.emacs.*` option namespace (gated by `marchyo.emacs.enable`) that ships:

- **Foundation** — Emacs PGTK daemon via `services.emacs`, frame plumbing
- **Cross-WM windmove** (closest analogue of the article) — SUPER+ALT+H/J/K/L tries `windmove-*` inside Emacs first, falls through to `hyprctl dispatch movefocus` at the frame edge. SUPER+ALT+SHIFT+HJKL does the same for window swap
- **Hyprland → Emacs eval channel** — example bind for `org-capture`, pattern is reusable
- **Emacs → Hyprland event subscription** — elisp listens on `.socket2.sock`, dispatches a hook on every event
- **persp.el sync** — mirror Hyprland workspace switches onto perspective.el
- **Scratchpad** — SUPER+Z toggles a named Emacs frame onto the existing `magic` special workspace
- **emacs-everywhere** — SUPER+CTRL+E, with wl-clipboard + wtype
- **org-protocol** — MIME registration so browser bookmarklets reach Emacs; SUPER+SHIFT+C → `(org-capture)`

Each sub-feature has its own `enable` flag (all default `true`). Elisp helpers ship to `~/.config/marchyo/emacs/` so they don't fight with the user's own init.el; opt in with `(load "~/.config/marchyo/emacs/marchyo-init.el")`.

## Files

- `modules/nixos/options/emacs.nix` (new) — `marchyo.emacs.*` option declarations
- `modules/home/emacs.nix` (new) — HM module: daemon, elisp glue, wrapper scripts, Hyprland binds + window rules
- `modules/home/xdg.nix` — register `x-scheme-handler/org-protocol` when enabled
- `tests/eval/emacs.nix` (new) — disabled / enabled / minimal eval tests

## Test plan

- [ ] CI runs `nix flake check` and `nix fmt -- --ci` (no nix tooling available in this remote session)
- [ ] On a host with `marchyo.emacs.enable = true`: `systemctl --user status emacs` shows the daemon active
- [ ] `SUPER+ALT+L` in an Emacs frame split horizontally moves the Emacs selection right; at the right edge, the next press hands focus to the adjacent Hyprland tile
- [ ] `SUPER+Z` toggles the scratchpad onto and off `magic`
- [ ] `SUPER+SHIFT+C` opens `org-capture`
- [ ] Workspace switches show up in `*Messages*` via the event listener (after `(marchyo-persp-enable)`)
- [ ] `emacsclient -e '(message "ok")'` round-trips

Marked as draft so CI can validate.

---
_Generated by [Claude Code](https://claude.ai/code/session_015dx3kUifixsqhxLCv3DeR2)_