### PR TITLE
chore: pin inputs to NixOS 26.05 release

### DIFF
--- a/devenv.lock
+++ b/devenv.lock
@@ -19,17 +19,17 @@
     },
     "nixpkgs": {
       "locked": {
-        "lastModified": 1779560665,
-        "narHash": "sha256-tpyBcxPpcQb8ukyNF7DoCwfSY3VPsxHoYwj00Cayv5o=",
+        "lastModified": 1779971959,
+        "narHash": "sha256-R5nauXyqyfRUFiZycFFZdkF7wl6eaUpPLst35+2nJQY=",
         "owner": "NixOS",
         "repo": "nixpkgs",
-        "rev": "64c08a7ca051951c8eae34e3e3cb1e202fe36786",
+        "rev": "ec942ba042dad5ef097e2ef3a3effc034241f011",
         "type": "github"
       },
       "original": {
         "owner": "NixOS",
         "repo": "nixpkgs",
-        "rev": "64c08a7ca051951c8eae34e3e3cb1e202fe36786",
+        "rev": "ec942ba042dad5ef097e2ef3a3effc034241f011",
         "type": "github"
       }
     },

--- a/devenv.yaml
+++ b/devenv.yaml
@@ -1,6 +1,6 @@
 inputs:
   nixpkgs:
-    url: github:NixOS/nixpkgs/64c08a7ca051951c8eae34e3e3cb1e202fe36786
+    url: github:NixOS/nixpkgs/ec942ba042dad5ef097e2ef3a3effc034241f011
   treefmt-nix:
     url: github:numtide/treefmt-nix/790751ff7fd3801feeaf96d7dc416a8d581265ba
     inputs:

--- a/flake.lock
+++ b/flake.lock
@@ -161,17 +161,18 @@
         ]
       },
       "locked": {
-        "lastModified": 1779969295,
-        "narHash": "sha256-HwIJ3tOcwSMiV75L7KqJXciXR9UfT+d7rwOZMX7cTnA=",
+        "lastModified": 1779726825,
+        "narHash": "sha256-RUkMrREjKDQrA+dA9+xZviGAxM5W1aVdyOr/bSYpHrE=",
         "owner": "nix-community",
         "repo": "home-manager",
-        "rev": "61e2c9659324181e0f0ed911958c536333b1d4f6",
+        "rev": "b179bde238977f7d4454fc770b1a727eaf55111c",
         "type": "github"
       },
       "original": {
         "owner": "nix-community",
         "repo": "home-manager",
-        "type": "github"
+        "type": "github",
+        "ref": "release-26.05"
       }
     },
     "jylhis-design": {
@@ -211,7 +212,8 @@
       "original": {
         "owner": "LnL7",
         "repo": "nix-darwin",
-        "type": "github"
+        "type": "github",
+        "ref": "nix-darwin-26.05"
       }
     },
     "nixos-hardware": {
@@ -232,18 +234,18 @@
     },
     "nixpkgs": {
       "locked": {
-        "lastModified": 1779560665,
-        "narHash": "sha256-tpyBcxPpcQb8ukyNF7DoCwfSY3VPsxHoYwj00Cayv5o=",
+        "lastModified": 1779971959,
+        "narHash": "sha256-R5nauXyqyfRUFiZycFFZdkF7wl6eaUpPLst35+2nJQY=",
         "owner": "NixOS",
         "repo": "nixpkgs",
-        "rev": "64c08a7ca051951c8eae34e3e3cb1e202fe36786",
+        "rev": "ec942ba042dad5ef097e2ef3a3effc034241f011",
         "type": "github"
       },
       "original": {
         "owner": "NixOS",
-        "ref": "nixos-unstable",
         "repo": "nixpkgs",
-        "type": "github"
+        "type": "github",
+        "ref": "nixos-26.05"
       }
     },
     "noctalia": {

--- a/flake.nix
+++ b/flake.nix
@@ -2,14 +2,14 @@
   description = "Marchyo";
 
   inputs = {
-    nixpkgs.url = "github:NixOS/nixpkgs/nixos-unstable";
+    nixpkgs.url = "github:NixOS/nixpkgs/nixos-26.05";
     nixos-hardware.url = "github:NixOS/nixos-hardware/master";
     flake-compat = {
       url = "github:edolstra/flake-compat";
       flake = false;
     };
     nix-darwin = {
-      url = "github:LnL7/nix-darwin";
+      url = "github:LnL7/nix-darwin/nix-darwin-26.05";
       inputs.nixpkgs.follows = "nixpkgs";
     };
     treefmt-nix = {
@@ -17,7 +17,7 @@
       inputs.nixpkgs.follows = "nixpkgs";
     };
     home-manager = {
-      url = "github:nix-community/home-manager";
+      url = "github:nix-community/home-manager/release-26.05";
       inputs.nixpkgs.follows = "nixpkgs";
     };
     stylix = {


### PR DESCRIPTION
## Summary

Pins the flake's release-aligned inputs to the **NixOS 26.05** stable release branches instead of `nixos-unstable` / default branches.

| Input | Before | After |
|-------|--------|-------|
| `nixpkgs` | `nixos-unstable` | `nixos-26.05` |
| `home-manager` | default branch | `release-26.05` |
| `nix-darwin` | default branch | `nix-darwin-26.05` |

`flake.lock` is updated accordingly (nixpkgs → `ec942ba`, home-manager → `b179bde`; nix-darwin's locked rev was already `56c666e` since master and the freshly-cut release branch share HEAD). `devenv.yaml` / `devenv.lock` nixpkgs are synced to the same revision so `just verify` passes.

## Inputs left as-is (intentional)

- **stylix** — has no `release-26.05` branch yet (latest is `release-25.11`); stays on its default branch and follows the pinned `nixpkgs`.
- **nixos-hardware** — rolling `master` (version-independent).
- **treefmt-nix** and the third-party inputs (**vicinae**, **noctalia**, **jylhis-design**) — no release branches; all `follows = "nixpkgs"`, so they ride the 26.05 pin.

## Validation

- `nix eval .#nixosConfigurations.x86_64...toplevel.drvPath` → `nixos-system-marchyo-x86-64-26.05.20260528.ec942ba` ✅
- All 46 `checks.x86_64-linux` evaluate without errors ✅
- `nix fmt -- --ci` → 0 files changed ✅
- `flake.lock` ↔ `devenv.lock` nixpkgs/treefmt-nix rev parity confirmed ✅

https://claude.ai/code/session_014Xgc5dshRUrEgzwywJRHAN

---
_Generated by [Claude Code](https://claude.ai/code/session_014Xgc5dshRUrEgzwywJRHAN)_