### PR TITLE
chore: pin inputs to NixOS 26.05 release

### DIFF
--- a/devenv.lock
+++ b/devenv.lock
@@ -19,17 +19,17 @@
     },
     "nixpkgs": {
       "locked": {
-        "lastModified": 1767892417,
-        "narHash": "sha256-dhhvQY67aboBk8b0/u0XB6vwHdgbROZT3fJAjyNh5Ww=",
+        "lastModified": 1780051219,
+        "narHash": "sha256-WnxzG4x47uCgjz+uD+vOzbF+Qid+hKyYdJWbduA9w7g=",
         "owner": "NixOS",
         "repo": "nixpkgs",
-        "rev": "3497aa5c9457a9d88d71fa93a4a8368816fbeeba",
+        "rev": "e8e446a361172fe838243958325845d0b845c5e5",
         "type": "github"
       },
       "original": {
         "owner": "NixOS",
         "repo": "nixpkgs",
-        "rev": "3497aa5c9457a9d88d71fa93a4a8368816fbeeba",
+        "rev": "e8e446a361172fe838243958325845d0b845c5e5",
         "type": "github"
       }
     },

--- a/devenv.yaml
+++ b/devenv.yaml
@@ -1,6 +1,6 @@
 inputs:
   nixpkgs:
-    url: github:NixOS/nixpkgs/3497aa5c9457a9d88d71fa93a4a8368816fbeeba
+    url: github:NixOS/nixpkgs/e8e446a361172fe838243958325845d0b845c5e5
   treefmt-nix:
     url: github:numtide/treefmt-nix/790751ff7fd3801feeaf96d7dc416a8d581265ba
     inputs:

--- a/flake.lock
+++ b/flake.lock
@@ -237,19 +237,6 @@
     },
     "nixpkgs": {
       "locked": {
-        "lastModified": 1767892417,
-        "narHash": "sha256-8bW3q88CEg2u4hSP66Vf4lpbLonHz7hqDNBMcCY7E9U=",
-        "rev": "3497aa5c9457a9d88d71fa93a4a8368816fbeeba",
-        "type": "tarball",
-        "url": "https://releases.nixos.org/nixos/unstable/nixos-26.05pre924538.3497aa5c9457/nixexprs.tar.xz"
-      },
-      "original": {
-        "type": "tarball",
-        "url": "https://channels.nixos.org/nixos-unstable/nixexprs.tar.xz"
-      }
-    },
-    "nixpkgs_2": {
-      "locked": {
         "lastModified": 1780051219,
         "narHash": "sha256-WnxzG4x47uCgjz+uD+vOzbF+Qid+hKyYdJWbduA9w7g=",
         "owner": "NixOS",
@@ -340,7 +327,7 @@
         "jylhis-design": "jylhis-design",
         "nix-darwin": "nix-darwin",
         "nixos-hardware": "nixos-hardware",
-        "nixpkgs": "nixpkgs_2",
+        "nixpkgs": "nixpkgs",
         "noctalia": "noctalia",
         "stylix": "stylix",
         "treefmt-nix": "treefmt-nix_2",


### PR DESCRIPTION
## Summary

Pins the flake to the **NixOS 26.05** release for all inputs that have a 26.05 release branch, and repairs an inconsistent lock left by an earlier partial re-lock.

### Already on 26.05 (in `flake.nix`)
- `nixpkgs` → `github:NixOS/nixpkgs/nixos-26.05`
- `home-manager` → `release-26.05`
- `nix-darwin` → `nix-darwin-26.05`

### Lock reconciliation (this PR's main fix)
The earlier re-lock left `flake.lock` with **two** nixpkgs nodes:
- root used a github `nixos-26.05` node (`nixpkgs_2`, `e8e446a`)
- **every** `follows = "nixpkgs"` input (home-manager, nix-darwin, stylix, treefmt-nix, vicinae, noctalia, jylhis-design, nixos-hardware, nur, flake-parts) still followed a **stale `nixos-unstable` channel tarball snapshot** (`3497aa5c`)

That broke the single-nixpkgs passthrough guarantee (the whole point of `inputs.*.nixpkgs.follows = "nixpkgs"`) and pulled two different nixpkgs revisions into the closure.

This PR collapses to **one** nixpkgs node tracking `github:NixOS/nixpkgs/nixos-26.05` and repoints root + all 12 follows at it. `devenv.lock`/`devenv.yaml` are synced to the same revision (reusing the recorded github narHash) so the `just verify` rev-parity check holds.

### Inputs without a 26.05 release branch
`stylix` (latest is `release-25.11`), `treefmt-nix`, `nixos-hardware`, `vicinae`, `noctalia`, `jylhis-design` publish no `release-26.05` branch. They keep `follows = "nixpkgs"` and therefore build against the single 26.05 nixpkgs. Per discussion, **stylix stays on its default branch** (closest to fresh 26.05) until upstream cuts `release-26.05`.

## Validation
- Verified the lock graph by hand: single `nixpkgs` node @ `e8e446a`, root + all follows resolve to it, no dangling `nixpkgs_2` refs.
- Simulated `just verify`: `nixpkgs` and `treefmt-nix` revs match between `flake.lock` and `devenv.lock`.
- Only **already-locked, nix-produced** blocks were reused — no hashes were invented.

> ⚠️ `nix` is not available in the execution environment, so `nix flake check` / `just check` could not be run here. Recommend running `just update && just check` once to confirm before merge.


---
_Generated by [Claude Code](https://claude.ai/code/session_014d7io9j4Dh3ANiiutLUKug)_