### PR TITLE
feat: replace GUI apps with TUI equivalents

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -247,16 +247,16 @@ marchyo.defaults = {
   editor = "jotain";              # emacs, jotain, vscode, vscodium, zed
   terminalEditor = "jotain";      # emacs, jotain, neovim, helix, nano
   videoPlayer = "mpv";            # mpv, vlc, celluloid
-  audioPlayer = "mpv";            # mpv, vlc, amberol
-  musicPlayer = "spotify";        # spotify
+  audioPlayer = "mpv";            # mpv, cmus, vlc, amberol
+  musicPlayer = "spotify-player"; # spotify-player, ncspot, spotify
   fileManager = "nautilus";       # nautilus, thunar
   terminalFileManager = "yazi";   # yazi, ranger, lf
   imageEditor = "pinta";         # pinta, gimp, krita
-  email = "gmail";               # gmail, thunderbird, outlook
+  email = "aerc";                # aerc, neomutt, gmail, thunderbird, outlook
 };
 ```
 
-`"jotain"` and web-based email (`"gmail"`, `"outlook"`) are externally managed — no package is installed by marchyo. The implementation is in `modules/nixos/defaults.nix`.
+`"jotain"` and web-based email (`"gmail"`, `"outlook"`) are externally managed — no package is installed by marchyo. The implementation is in `modules/nixos/defaults.nix`. The default music (`spotify-player`) and mail (`aerc`) clients are TUIs; the music client launches in a floating terminal under Hyprland.
 
 ### Keyboard & Input Methods
 

--- a/docs/configuration/default-apps.mdx
+++ b/docs/configuration/default-apps.mdx
@@ -13,12 +13,12 @@ When `marchyo.desktop.enable = true`, the `marchyo.defaults.*` options control w
 | `marchyo.defaults.editor` | `"jotain"` | `"emacs"`, `"jotain"`, `"vscode"`, `"vscodium"`, `"zed"` |
 | `marchyo.defaults.terminalEditor` | `"jotain"` | `"emacs"`, `"jotain"`, `"neovim"`, `"helix"`, `"nano"` |
 | `marchyo.defaults.videoPlayer` | `"mpv"` | `"mpv"`, `"vlc"`, `"celluloid"` |
-| `marchyo.defaults.audioPlayer` | `"mpv"` | `"mpv"`, `"vlc"`, `"amberol"` |
-| `marchyo.defaults.musicPlayer` | `"spotify"` | `"spotify"` |
+| `marchyo.defaults.audioPlayer` | `"mpv"` | `"mpv"`, `"cmus"`, `"vlc"`, `"amberol"` |
+| `marchyo.defaults.musicPlayer` | `"spotify-player"` | `"spotify-player"`, `"ncspot"`, `"spotify"` |
 | `marchyo.defaults.fileManager` | `"nautilus"` | `"nautilus"`, `"thunar"` |
 | `marchyo.defaults.terminalFileManager` | `"yazi"` | `"yazi"`, `"ranger"`, `"lf"` |
 | `marchyo.defaults.imageEditor` | `"pinta"` | `"pinta"`, `"gimp"`, `"krita"` |
-| `marchyo.defaults.email` | `"gmail"` | `"gmail"`, `"thunderbird"`, `"outlook"` |
+| `marchyo.defaults.email` | `"aerc"` | `"aerc"`, `"neomutt"`, `"gmail"`, `"thunderbird"`, `"outlook"` |
 
 ## Example
 
@@ -28,12 +28,12 @@ marchyo.defaults = {
   editor = "vscode";
   terminalEditor = "neovim";
   videoPlayer = "mpv";
-  audioPlayer = "mpv";
-  musicPlayer = "spotify";
+  audioPlayer = "mpv";        # or "cmus" for a TUI library player
+  musicPlayer = "spotify-player";  # TUI Spotify client (floating terminal)
   fileManager = "nautilus";
   terminalFileManager = "yazi";
   imageEditor = "gimp";
-  email = "thunderbird";
+  email = "aerc";             # TUI mail client; requires account config
 };
 ```
 
@@ -54,6 +54,10 @@ Some choices are "externally managed" — Marchyo does not install a package for
 
 - **`"jotain"`** (editor/terminalEditor) — Package installation and `$EDITOR`/`$VISUAL` are handled by `programs.jotain` outside of Marchyo.
 - **`"gmail"`** and **`"outlook"`** (email) — Web applications opened in the default browser. No package is installed.
+
+<Note>
+  The TUI music (`spotify-player`, `ncspot`) and mail (`aerc`, `neomutt`) clients are installed but require account configuration before use. The music clients launch in a floating terminal under Hyprland (Super+M).
+</Note>
 
 ## How defaults work
 

--- a/modules/home/hyprland.nix
+++ b/modules/home/hyprland.nix
@@ -41,6 +41,9 @@ let
   };
 
   musicHyprlandCommands = {
+    # TUI clients launch in a floating terminal (Omarchy pattern, see window rule below)
+    spotify-player = "$terminal --class=org.omarchy.spotify-player -e spotify-player";
+    ncspot = "$terminal --class=org.omarchy.ncspot -e ncspot";
     spotify = "spotify";
   };
 
@@ -58,7 +61,7 @@ let
 
   musicCmd =
     let
-      m = marchyoDefaults.musicPlayer or "spotify";
+      m = marchyoDefaults.musicPlayer or "spotify-player";
     in
     if m == null then "xdg-open" else musicHyprlandCommands.${m};
 
@@ -249,7 +252,7 @@ in
           "center on, match:tag floating-window"
           "size 875 600, match:tag floating-window"
 
-          "tag +floating-window, match:class (org.omarchy.bluetui|org.omarchy.impala|org.omarchy.wiremix|org.omarchy.btop|org.omarchy.terminal|org.omarchy.bash|org.gnome.NautilusPreviewer|org.gnome.Evince|com.gabm.satty|Omarchy|About|TUI.float|imv|mpv)"
+          "tag +floating-window, match:class (org.omarchy.bluetui|org.omarchy.impala|org.omarchy.wiremix|org.omarchy.btop|org.omarchy.spotify-player|org.omarchy.ncspot|org.omarchy.terminal|org.omarchy.bash|org.gnome.NautilusPreviewer|org.gnome.Evince|com.gabm.satty|Omarchy|About|TUI.float|imv|mpv)"
           "tag +floating-window, match:class (xdg-desktop-portal-gtk|sublime_text|DesktopEditors|org.gnome.Nautilus), match:title ^(Open.*Files?|Open [F|f]older.*|Save.*Files?|Save.*As|Save|All Files|.*wants to [open|save].*|[C|c]hoose.*)"
 
           # Fullscreen screensaver

--- a/modules/home/xdg.nix
+++ b/modules/home/xdg.nix
@@ -40,6 +40,12 @@ let
     thunar = "thunar.desktop";
   };
 
+  # TUI mail clients ship a Terminal=true desktop file; web/null get none.
+  emailDesktopFiles = {
+    aerc = "aerc.desktop";
+    thunderbird = "thunderbird.desktop";
+  };
+
   browser = defaults.browser or null;
   editor = defaults.editor or null;
   videoPlayer = defaults.videoPlayer or null;
@@ -51,8 +57,14 @@ let
   editorDesktop = lib.optional (
     editor != null && builtins.hasAttr editor editorDesktopFiles
   ) editorDesktopFiles.${editor};
-  videoDesktop = lib.optional (videoPlayer != null) videoPlayerDesktopFiles.${videoPlayer};
-  audioDesktop = lib.optional (audioPlayer != null) audioPlayerDesktopFiles.${audioPlayer};
+  # TUI players (e.g. cmus) have no single-file MIME handler; hasAttr-guard so
+  # selecting one simply registers no association instead of failing eval.
+  videoDesktop = lib.optional (
+    videoPlayer != null && builtins.hasAttr videoPlayer videoPlayerDesktopFiles
+  ) videoPlayerDesktopFiles.${videoPlayer};
+  audioDesktop = lib.optional (
+    audioPlayer != null && builtins.hasAttr audioPlayer audioPlayerDesktopFiles
+  ) audioPlayerDesktopFiles.${audioPlayer};
   fileManagerDesktop = lib.optional (fileManager != null) fileManagerDesktopFiles.${fileManager};
 
   browserMimeTypes = lib.optionalAttrs (browserDesktop != [ ]) {
@@ -88,12 +100,13 @@ let
     "inode/directory" = fileManagerDesktop;
   };
 
-  # mailto: thunderbird gets its own desktop file; gmail/outlook open in browser
+  # mailto: aerc/thunderbird get their own desktop file; gmail/outlook (and any
+  # client without a desktop file) fall back to opening in the browser.
   emailMimeTypes =
     if email == null then
       { }
-    else if email == "thunderbird" then
-      { "x-scheme-handler/mailto" = [ "thunderbird.desktop" ]; }
+    else if builtins.hasAttr email emailDesktopFiles then
+      { "x-scheme-handler/mailto" = [ emailDesktopFiles.${email} ]; }
     else if browserDesktop != [ ] then
       { "x-scheme-handler/mailto" = browserDesktop; }
     else
@@ -125,16 +138,7 @@ in
         # Documents
         "application/pdf" = [ "org.gnome.Papers.desktop" ];
 
-        # Archives
-        "application/zip" = [ "org.gnome.FileRoller.desktop" ];
-        "application/x-tar" = [ "org.gnome.FileRoller.desktop" ];
-        "application/gzip" = [ "org.gnome.FileRoller.desktop" ];
-        "application/x-compressed-tar" = [ "org.gnome.FileRoller.desktop" ];
-        "application/x-bzip-compressed-tar" = [ "org.gnome.FileRoller.desktop" ];
-        "application/x-xz-compressed-tar" = [ "org.gnome.FileRoller.desktop" ];
-        "application/x-7z-compressed" = [ "org.gnome.FileRoller.desktop" ];
-        "application/x-rar" = [ "org.gnome.FileRoller.desktop" ];
-        "application/vnd.rar" = [ "org.gnome.FileRoller.desktop" ];
+        # Archives are handled from the terminal (ouch / yazi); no GUI handler.
       }
       // fileManagerMimeTypes
       // videoMimeTypes

--- a/modules/nixos/defaults.nix
+++ b/modules/nixos/defaults.nix
@@ -62,11 +62,14 @@ let
 
   audioPlayerPackages = {
     inherit (pkgs) mpv; # shared with video when same; NixOS deduplicates
+    inherit (pkgs) cmus;
     inherit (pkgs) vlc;
     inherit (pkgs) amberol;
   };
 
   musicPlayerPackages = {
+    inherit (pkgs) spotify-player;
+    inherit (pkgs) ncspot;
     inherit (pkgs) spotify;
   };
 
@@ -91,6 +94,8 @@ let
   # gmail → https://mail.google.com (TODO: register as PWA)
   # outlook → https://outlook.com (TODO: register as PWA)
   emailPackages = {
+    inherit (pkgs) aerc;
+    inherit (pkgs) neomutt;
     inherit (pkgs) thunderbird;
   };
 
@@ -115,10 +120,11 @@ in
 {
   config = lib.mkIf cfg.desktop.enable (
     lib.mkMerge [
-      # google-chrome and spotify are x86_64-only on Linux
+      # google-chrome is x86_64-only on Linux; the default TUI music player
+      # (spotify-player) builds on aarch64, so only the browser needs a fallback.
+      # Selecting the GUI "spotify" on aarch64 remains unsupported.
       (lib.mkIf (!pkgs.stdenv.hostPlatform.isx86_64) {
         marchyo.defaults.browser = lib.mkDefault "chromium";
-        marchyo.defaults.musicPlayer = lib.mkDefault null;
       })
       {
         environment.systemPackages = defaultPackages;

--- a/modules/nixos/media.nix
+++ b/modules/nixos/media.nix
@@ -1,23 +1,10 @@
+{ pkgs, ... }:
 {
-  pkgs,
-  lib,
-  config,
-  ...
-}:
-{
-  environment.systemPackages =
-    with pkgs;
-    [
-      # File format support
-      libheif
+  environment.systemPackages = with pkgs; [
+    # File format support
+    libheif
 
-      # Players
-      mpv
-    ]
-    ++ (lib.optionals config.nixpkgs.config.allowUnfree (
-      lib.optionals (pkgs.stdenv.hostPlatform.system == "x86_64-linux") [
-        pkgs.spotify
-      ]
-    ));
-
+    # Players (music streaming handled by marchyo.defaults.musicPlayer)
+    mpv
+  ];
 }

--- a/modules/nixos/options/defaults.nix
+++ b/modules/nixos/options/defaults.nix
@@ -84,26 +84,39 @@ in
       type = types.nullOr (
         types.enum [
           "mpv"
+          "cmus"
           "vlc"
           "amberol"
         ]
       );
       default = "mpv";
-      example = "vlc";
+      example = "cmus";
       description = ''
         Default audio player for local files. Installed automatically when
         desktop is enabled and registered as the system default for audio
-        MIME types. Set to null to skip audio player management.
+        MIME types. "mpv" plays files headlessly in a terminal and remains
+        the file-open default; "cmus" is a TUI library player launched
+        manually (no single-file MIME handler). Set to null to skip audio
+        player management.
       '';
     };
 
     musicPlayer = mkOption {
-      type = types.nullOr (types.enum [ "spotify" ]);
-      default = "spotify";
-      example = "spotify";
+      type = types.nullOr (
+        types.enum [
+          "spotify-player"
+          "ncspot"
+          "spotify"
+        ]
+      );
+      default = "spotify-player";
+      example = "ncspot";
       description = ''
-        Default music streaming player. Installed automatically when desktop
-        is enabled. Set to null to skip music player management.
+        Default music streaming player. Defaults to "spotify-player", a TUI
+        Spotify client launched in a floating terminal. "ncspot" is an
+        alternative TUI client; "spotify" installs the GUI app (x86_64-only).
+        Installed automatically when desktop is enabled. Set to null to skip
+        music player management.
       '';
     };
 
@@ -158,17 +171,22 @@ in
     email = mkOption {
       type = types.nullOr (
         types.enum [
+          "aerc"
+          "neomutt"
           "gmail"
           "thunderbird"
           "outlook"
         ]
       );
-      default = "gmail";
+      default = "aerc";
       example = "thunderbird";
       description = ''
-        Default email client. "gmail" and "outlook" are web apps opened in
-        the browser (no package installed). "thunderbird" installs the native
-        client. Set to null to skip email management.
+        Default email client. Defaults to "aerc", a TUI mail client (mailto
+        links open it in a terminal). "neomutt" is an alternative TUI client.
+        Both require account configuration before use. "gmail" and "outlook"
+        are web apps opened in the browser (no package installed).
+        "thunderbird" installs the native GUI client. Set to null to skip
+        email management.
       '';
     };
   };

--- a/modules/nixos/packages.nix
+++ b/modules/nixos/packages.nix
@@ -27,26 +27,25 @@ let
     lnav
     tailspin
     nix-output-monitor
+    ouch # archive compression/extraction (replaces file-roller)
   ];
 
   tuiTools = with pkgs; [
-    btop # beautiful resource manager
+    btop # beautiful resource manager (replaces gnome-system-monitor)
     fastfetch # shows system information
     bluetui # bluetooth
     sysz # systemctl tui
     lazyjournal # journald and logs
     impala # TUI for managing your Wi-Fi connection
+    libqalculate # qalc — calculator REPL (replaces gnome-calculator)
   ];
 
   # Desktop GUI tools
   desktopTools = with pkgs; [
     signal-desktop # E2E messaging
     localsend # send files to other devices on the same network
-    file-roller # Archive manager
     loupe # Modern GNOME image viewer
     gnome-disk-utility # Disk management
-    gnome-calculator # Calculator
-    gnome-system-monitor # System monitoring
     sushi # Quick file previews in Nautilus
     dconf-editor # For debugging dconf/GTK settings
   ];

--- a/tests/eval/defaults.nix
+++ b/tests/eval/defaults.nix
@@ -44,6 +44,16 @@ in
     };
   });
 
+  # TUI-flipped defaults: spotify-player (music), cmus (audio), aerc (email).
+  eval-defaults-tui = testNixOS "defaults-tui" (withTestUser {
+    marchyo.desktop.enable = true;
+    marchyo.defaults = {
+      musicPlayer = "spotify-player";
+      audioPlayer = "cmus";
+      email = "aerc";
+    };
+  });
+
   # Jotain is externally managed (no package installed by marchyo).
   eval-defaults-jotain = testNixOS "defaults-jotain" (withTestUser {
     marchyo.desktop.enable = true;


### PR DESCRIPTION
## Summary

Migrates desktop GUI applications to terminal-UI equivalents where a TUI fully covers the functionality, and flips the configurable `marchyo.defaults.*` app choices so the TUI option is the default. GUI choices remain selectable — nothing is removed from the enums.

This continues the existing Omarchy-style pattern (the desktop already runs `btop`, `impala`, `bluetui`, `yazi`, `lazygit`, `lazydocker`, `k9s` as TUIs in floating terminals).

Scope: **Balanced** — clear wins replaced, TUI options added, GUI kept. Image viewer (`loupe`), PDF (`papers`), notes (`obsidian`), messenger (`signal-desktop`), and browser are intentionally left as GUI (no TUI equal). `modules/darwin/homebrew.nix` is untouched.

## Changes

**Hardcoded tool swaps** (`modules/nixos/packages.nix`)
| Removed (GUI) | Replacement (TUI/CLI) |
|---|---|
| `gnome-system-monitor` | `btop` (already installed) |
| `gnome-calculator` | `qalc` (`libqalculate`) |
| `file-roller` | `ouch` + `yazi` (archive MIME associations dropped) |

**Configurable defaults flipped to TUI** (`options/defaults.nix`, `defaults.nix`)
- `musicPlayer`: default → `spotify-player` (TUI); `ncspot` added; `spotify` GUI kept
- `email`: default → `aerc` (TUI); `neomutt` added; `gmail`/`outlook`/`thunderbird` kept
- `audioPlayer`: `cmus` added as a TUI option (`mpv` stays the file-open default since it's already terminal-capable and has a MIME handler)

**Wiring**
- `media.nix` no longer hardcodes the Spotify GUI; music comes from `defaults`
- `defaults.nix` drops the aarch64 `musicPlayer = null` guard — `spotify-player` builds on aarch64; selecting the GUI `spotify` on aarch64 stays an unsupported user choice
- `hyprland.nix` launches the TUI music clients in a floating terminal (`--class=org.omarchy.spotify-player`) and adds those classes to the floating-window rule
- `xdg.nix` `hasAttr`-guards the video/audio desktop-file lookups (so a TUI player with no `.desktop` file just registers no association) and routes `mailto:` to `aerc`/`thunderbird`, falling back to the browser

**Docs & tests**
- `CLAUDE.md` and `docs/configuration/default-apps.mdx` updated
- New `eval-defaults-tui` eval test (`musicPlayer = spotify-player`, `audioPlayer = cmus`, `email = aerc`)

## Tradeoffs (Balanced tier)
- The GUI file manager (nautilus) no longer auto-opens archives — extraction moves to `ouch`/`yazi`.
- `email` default flips from zero-config web Gmail to `aerc`, which needs an account configured before use (documented in the option description).

## Verification
Nix tooling isn't available in the build container, so `just check` / `just fmt` were not run locally — CI lint + check (incl. the new eval test) will validate. Changes were syntax- and convention-reviewed by hand; `testNixOS` only forces assertions + `stateVersion`, so no x86_64-only package is forced during aarch64 eval.

https://claude.ai/code/session_01LMzFvzkV5t9mZASn8SEniV

---
_Generated by [Claude Code](https://claude.ai/code/session_01LMzFvzkV5t9mZASn8SEniV)_