### PR TITLE
fix: migrate vicinae HM options to programs.vicinae namespace

### DIFF
--- a/modules/home/hyprland.nix
+++ b/modules/home/hyprland.nix
@@ -426,7 +426,7 @@ in
         exec-once = [
           # Essential services
           "kanshi"
-          # vicinae runs as a user service (services.vicinae.systemd.enable)
+          # vicinae runs as a user service (programs.vicinae.systemd.enable)
           "fcitx5 -d --replace"
 
           # Clipboard

--- a/modules/home/vicinae.nix
+++ b/modules/home/vicinae.nix
@@ -9,7 +9,7 @@ let
 in
 {
   config = lib.mkIf desktopEnabled {
-    services.vicinae = {
+    programs.vicinae = {
       enable = true;
       systemd.enable = true; # run the daemon as a user service (Restart=always, WantedBy=graphical-session.target)
       settings = {

--- a/tests/eval/headless.nix
+++ b/tests/eval/headless.nix
@@ -33,7 +33,7 @@ in
         ++ lib.optional hm.programs.waybar.enable "waybar"
         ++ lib.optional hm.programs.hyprlock.enable "hyprlock"
         ++ lib.optional hm.services.hypridle.enable "hypridle"
-        ++ lib.optional hm.services.vicinae.enable "vicinae"
+        ++ lib.optional hm.programs.vicinae.enable "vicinae"
         ++ lib.optional hm.programs.noctalia.enable "noctalia";
     in
     pkgs.writeText "eval-headless-no-wayland" (


### PR DESCRIPTION
## Summary

`nix flake check` emitted deprecation traces because the upstream vicinae Home Manager module renamed `services.vicinae.*` → `programs.vicinae.*`. This migrates our usages to the new namespace.

## Changes

- `modules/home/vicinae.nix` — `services.vicinae` → `programs.vicinae`
- `tests/eval/headless.nix` — read `hm.programs.vicinae.enable` instead of the obsolete `services.vicinae.enable` alias (reading the alias itself triggered an "Obsolete option" trace)
- `modules/home/hyprland.nix` — update a stale code comment to the new option name

## Verification

- `nix flake check` → exit 0
- `nix fmt -- --ci` → 0 files changed

## Remaining (not actionable in this repo)

- `services.vicinae.settings`/`themes` traces still appear, but they originate **entirely in the upstream vicinae stylix module** (`modules/vicinae/hm.nix`'s `genAttrs ["services" "programs"]` helper writes the deprecated alias). Cannot be fixed without patching the dependency.
- The `marchyo: CPU mitigations are disabled` trace is an **intentional** by-design security notice (fires when `development.enable` + `disableMitigations` are both on).
- `warning: The check omitted these incompatible systems` is the expected notice that darwin/aarch64 aren't cross-evaluated on the x86_64-linux host (CI covers them on native runners).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01PGm5HPL8uVhD6tSMD1aLDi)_