### PR TITLE
feat: add SUPER+K on-screen keybinding cheat sheet

### DIFF
--- a/docs/configuration/feature-flags.mdx
+++ b/docs/configuration/feature-flags.mdx
@@ -40,7 +40,7 @@ Since these use `lib.mkDefault`, you can override them:
 
 When `marchyo.desktop.enable = true`, Marchyo configures:
 
-- **Hyprland** — Wayland compositor with pre-configured keybindings and window rules
+- **Hyprland** — Wayland compositor with pre-configured keybindings and window rules. Press <kbd>SUPER</kbd>+<kbd>K</kbd> for a searchable, on-screen cheat sheet of all active keybindings (toggle with `marchyo.keybindingsHelp.enable`)
 - **Audio** — PipeWire with PulseAudio and ALSA compatibility
 - **Bluetooth** — Enabled and configured
 - **Fonts** — Curated set of fonts including Nerd Fonts

--- a/modules/home/keybindings-cheatsheet.nix
+++ b/modules/home/keybindings-cheatsheet.nix
@@ -28,22 +28,24 @@ let
       binds=$(
         hyprctl binds -j | jq -r '
           def bit($b): (. / $b | floor) % 2 == 1;
-          .[]
-          | select(.description != "")
-          | (.modmask) as $m
-          | ([ (if ($m | bit(64)) then "SUPER" else empty end),
-               (if ($m | bit(4))  then "CTRL"  else empty end),
-               (if ($m | bit(8))  then "ALT"   else empty end),
-               (if ($m | bit(1))  then "SHIFT" else empty end) ]
-             | join("+")) as $mods
-          | (if .key != "" then .key
-             elif (.keycode >= 10 and .keycode <= 18) then ((.keycode - 9) | tostring)
-             elif .keycode == 19 then "0"
-             elif .keycode != 0 then "code:\(.keycode)"
-             else "mouse" end) as $key
-          | (if $mods == "" then $key else "\($mods)+\($key)" end) as $combo
-          | "\($combo)\t\(.description)"
-        ' | sort -u
+          [
+            .[]
+            | select(.description and .description != "")
+            | (.modmask) as $m
+            | ([ (if ($m | bit(64)) then "SUPER" else empty end),
+                 (if ($m | bit(4))  then "CTRL"  else empty end),
+                 (if ($m | bit(8))  then "ALT"   else empty end),
+                 (if ($m | bit(1))  then "SHIFT" else empty end) ]
+               | join("+")) as $mods
+            | (if .key and .key != "" then .key
+               elif (.keycode >= 10 and .keycode <= 18) then ((.keycode - 9) | tostring)
+               elif .keycode == 19 then "0"
+               elif .keycode != 0 then "code:\(.keycode)"
+               else "mouse" end) as $key
+            | (if $mods == "" then $key else "\($mods)+\($key)" end) as $combo
+            | "\($combo)\t\(.description)"
+          ] | unique[]
+        '
       )
 
       if [ -z "$binds" ]; then

--- a/modules/home/keybindings-cheatsheet.nix
+++ b/modules/home/keybindings-cheatsheet.nix
@@ -1,0 +1,82 @@
+{
+  lib,
+  pkgs,
+  config,
+  osConfig ? { },
+  ...
+}:
+let
+  inherit (lib) mkIf mkEnableOption;
+  cfg = config.marchyo.keybindingsHelp;
+  desktopEnabled = pkgs.stdenv.isLinux && ((osConfig.marchyo or { }).desktop.enable or false);
+
+  # Renders the live Hyprland bind table (the `bindd` entries carry
+  # human-readable descriptions) into a searchable overlay. Reading from
+  # `hyprctl binds -j` at runtime means the sheet always reflects the actual
+  # running config, including any binds added by downstream consumers.
+  cheatsheet = pkgs.writeShellApplication {
+    name = "marchyo-keybindings";
+    runtimeInputs = with pkgs; [
+      hyprland # hyprctl
+      jq
+      fzf
+      gawk
+    ];
+    text = ''
+      # Pull every described bind, decode the modifier bitmask into readable
+      # names, and emit "MODS+KEY<TAB>description" rows.
+      binds=$(
+        hyprctl binds -j | jq -r '
+          def bit($b): (. / $b | floor) % 2 == 1;
+          .[]
+          | select(.description != "")
+          | (.modmask) as $m
+          | ([ (if ($m | bit(64)) then "SUPER" else empty end),
+               (if ($m | bit(4))  then "CTRL"  else empty end),
+               (if ($m | bit(8))  then "ALT"   else empty end),
+               (if ($m | bit(1))  then "SHIFT" else empty end) ]
+             | join("+")) as $mods
+          | (if .key != "" then .key
+             elif (.keycode >= 10 and .keycode <= 18) then ((.keycode - 9) | tostring)
+             elif .keycode == 19 then "0"
+             elif .keycode != 0 then "code:\(.keycode)"
+             else "mouse" end) as $key
+          | (if $mods == "" then $key else "\($mods)+\($key)" end) as $combo
+          | "\($combo)\t\(.description)"
+        ' | sort -u
+      )
+
+      if [ -z "$binds" ]; then
+        echo "No described keybindings found." >&2
+        exit 1
+      fi
+
+      printf '%s\n' "$binds" \
+        | awk -F'\t' '{ printf "%-24s  %s\n", $1, $2 }' \
+        | fzf \
+            --reverse \
+            --no-sort \
+            --cycle \
+            --prompt 'keybindings> ' \
+            --header 'Hyprland keybindings — type to filter, Esc to close' \
+          || true
+    '';
+  };
+in
+{
+  options.marchyo.keybindingsHelp = {
+    enable = mkEnableOption "on-screen Hyprland keybinding cheat sheet (SUPER+K)" // {
+      default = true;
+    };
+  };
+
+  config = mkIf (desktopEnabled && cfg.enable) {
+    home.packages = [ cheatsheet ];
+
+    # Reuse the existing floating-terminal class so the overlay picks up the
+    # centered floating-window rule from hyprland.nix without a new windowrule.
+    wayland.windowManager.hyprland.settings.bindd = [
+      "SUPER, K, Keybindings cheat sheet, exec, $terminal --class=org.omarchy.terminal -e marchyo-keybindings"
+    ];
+  };
+}

--- a/tests/eval/hyprland.nix
+++ b/tests/eval/hyprland.nix
@@ -107,10 +107,7 @@ in
       hasBind = lib.any (b: lib.hasInfix "marchyo-keybindings" b) bindd;
     in
     pkgs.writeText "eval-hyprland-keybindings-cheatsheet-disabled" (
-      if hasBind then
-        throw "FAIL: keybindings cheat sheet bind present when disabled"
-      else
-        "pass"
+      if hasBind then throw "FAIL: keybindings cheat sheet bind present when disabled" else "pass"
     );
 
   eval-hyprland-wallpaper-enabled =

--- a/tests/eval/hyprland.nix
+++ b/tests/eval/hyprland.nix
@@ -92,18 +92,15 @@ in
         modules = [
           nixosModules
           (withTestUser {
-            marchyo = {
-              desktop.enable = true;
-              keybindingsHelp.enable = false;
-            };
+            marchyo.desktop.enable = true;
             home-manager.users.testuser = {
               imports = [ homeManagerModules ];
+              marchyo.keybindingsHelp.enable = false;
             };
           })
         ];
       };
-      bindd =
-        eval.config.home-manager.users.testuser.wayland.windowManager.hyprland.settings.bindd;
+      bindd = eval.config.home-manager.users.testuser.wayland.windowManager.hyprland.settings.bindd;
       hasBind = lib.any (b: lib.hasInfix "marchyo-keybindings" b) bindd;
     in
     pkgs.writeText "eval-hyprland-keybindings-cheatsheet-disabled" (

--- a/tests/eval/hyprland.nix
+++ b/tests/eval/hyprland.nix
@@ -59,6 +59,60 @@ in
         touch $out
       '';
 
+  eval-hyprland-keybindings-cheatsheet =
+    let
+      eval = lib.nixosSystem {
+        inherit (pkgs.stdenv.hostPlatform) system;
+        modules = [
+          nixosModules
+          (withTestUser {
+            marchyo.desktop.enable = true;
+            home-manager.users.testuser = {
+              imports = [ homeManagerModules ];
+            };
+          })
+        ];
+      };
+      hm = eval.config.home-manager.users.testuser;
+      bindd = hm.wayland.windowManager.hyprland.settings.bindd;
+      hasBind = lib.any (b: lib.hasInfix "marchyo-keybindings" b) bindd;
+      hasPkg = lib.any (p: lib.hasInfix "marchyo-keybindings" (p.name or "")) hm.home.packages;
+    in
+    pkgs.writeText "eval-hyprland-keybindings-cheatsheet" (
+      if hasBind && hasPkg then
+        "pass"
+      else
+        throw "FAIL: keybindings cheat sheet bind or package missing when desktop enabled"
+    );
+
+  eval-hyprland-keybindings-cheatsheet-disabled =
+    let
+      eval = lib.nixosSystem {
+        inherit (pkgs.stdenv.hostPlatform) system;
+        modules = [
+          nixosModules
+          (withTestUser {
+            marchyo = {
+              desktop.enable = true;
+              keybindingsHelp.enable = false;
+            };
+            home-manager.users.testuser = {
+              imports = [ homeManagerModules ];
+            };
+          })
+        ];
+      };
+      bindd =
+        eval.config.home-manager.users.testuser.wayland.windowManager.hyprland.settings.bindd;
+      hasBind = lib.any (b: lib.hasInfix "marchyo-keybindings" b) bindd;
+    in
+    pkgs.writeText "eval-hyprland-keybindings-cheatsheet-disabled" (
+      if hasBind then
+        throw "FAIL: keybindings cheat sheet bind present when disabled"
+      else
+        "pass"
+    );
+
   eval-hyprland-wallpaper-enabled =
     let
       eval = lib.nixosSystem {


### PR DESCRIPTION
## What

Adds a searchable, on-screen **keybinding cheat sheet** for the Hyprland desktop, bound to <kbd>SUPER</kbd>+<kbd>K</kbd>.

There was no existing binding to show keybindings on screen — only `man`/info via `help.nix`. This fills that gap.

## How it works

- A `marchyo-keybindings` script (built with `writeShellApplication`) reads the **live** config via `hyprctl binds -j`, so the sheet always reflects reality — including all the descriptive `bindd` entries spread across modules (`hyprland.nix`, `screenshot.nix`, `ai-tooling`, …) and any binds added downstream.
- `jq` decodes the modifier bitmask into readable names (`SUPER`/`CTRL`/`ALT`/`SHIFT`) and maps number-row keycodes (`code:10`) back to digits (`1`).
- The result is shown in `fzf` (type to filter, Esc to close) inside the existing `org.omarchy.terminal` floating-window class — no new window rule needed.

Sample output:

```
CTRL+ALT+Delete           Power off
Print                     Screenshot area/window
SUPER+K                   Keybindings cheat sheet
SUPER+SHIFT+1             Move window to workspace 1
SUPER+return              Terminal
```

## Details

- New module: `modules/home/keybindings-cheatsheet.nix` (auto-discovered).
- New option `marchyo.keybindingsHelp.enable` (default `true`, desktop-only) to toggle it — follows the `screenshot.nix` precedent for home-level desktop options.
- Eval tests for both the enabled and disabled paths in `tests/eval/hyprland.nix`. The existing `check-home-hyprland-config` test also validates the new `bindd` entry via `hyprland --verify-config`.
- Docs note added under desktop feature flags.

## Notes

- `nix`/`nixfmt`/`shellcheck` were not available in this remote environment, so formatting was hand-matched to `nixfmt` style and the `jq`/`awk` pipeline was validated against sample bind data locally. Please run `just check` / `just fmt` before merging out of draft.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_014j3mahehdGosszuR18myGQ

---
_Generated by [Claude Code](https://claude.ai/code/session_014j3mahehdGosszuR18myGQ)_